### PR TITLE
Proper teardown and ws target updates

### DIFF
--- a/data/Examples/blm.lua
+++ b/data/Examples/blm.lua
@@ -1,21 +1,21 @@
 xivhotbar_keybinds_job['Base'] = {
 
   -- Hotbar #
-  { 'battle 1 3',  'ma', 'Stun',           't',     'Stun' },
   { 'battle 1 2',  'ja', 'Cascade',        'me',    'Cascade' },
+  { 'battle 1 3',  'ma', 'Stun',           't',     'Stun' },
   { 'battle 1 4',  'ja', 'Elemental Seal', 'me',    'Ele.Seal' },
-  { 'battle 1 5',  'ma', 'Quake',          'stnpc', 'Quake' },
-  { 'battle 1 5',  'ma', 'Quake II',       'stnpc', 'Quake2' },
-  { 'battle 1 6',  'ma', 'Flood',          'stnpc', 'Flood' },
-  { 'battle 1 6',  'ma', 'Flood II',       'stnpc', 'Flood2' },
-  { 'battle 1 7',  'ma', 'Tornado',        'stnpc', 'Tornado' },
-  { 'battle 1 7',  'ma', 'Tornado II',     'stnpc', 'Tornado2' },
-  { 'battle 1 8',  'ma', 'Flare',          'stnpc', 'Flare' },
-  { 'battle 1 8',  'ma', 'Flare II',       'stnpc', 'Flare2' },
-  { 'battle 1 9',  'ma', 'Freeze',         'stnpc', 'Freeze' },
-  { 'battle 1 9',  'ma', 'Freeze II',      'stnpc', 'Freeze2' },
-  { 'battle 1 10', 'ma', 'Burst',          'stnpc', 'Burst' },
-  { 'battle 1 10', 'ma', 'Burst II',       'stnpc', 'Burst2' },
+  { 'battle 1 5',  'ma', 'Quake',          't',     'Quake' },
+  { 'battle 1 5',  'ma', 'Quake II',       't',     'Quake2' },
+  { 'battle 1 6',  'ma', 'Flood',          't',     'Flood' },
+  { 'battle 1 6',  'ma', 'Flood II',       't',     'Flood2' },
+  { 'battle 1 7',  'ma', 'Tornado',        't',     'Tornado' },
+  { 'battle 1 7',  'ma', 'Tornado II',     't',     'Tornado2' },
+  { 'battle 1 8',  'ma', 'Flare',          't',     'Flare' },
+  { 'battle 1 8',  'ma', 'Flare II',       't',     'Flare2' },
+  { 'battle 1 9',  'ma', 'Freeze',         't',     'Freeze' },
+  { 'battle 1 9',  'ma', 'Freeze II',      't',     'Freeze2' },
+  { 'battle 1 10', 'ma', 'Burst',          't',     'Burst' },
+  { 'battle 1 10', 'ma', 'Burst II',       't',     'Burst2' },
 
   -- ws reserved
   { 'battle 1 12', 'ja', 'Enmity Douse',   'stnpc', 'E.Douse' },
@@ -36,152 +36,146 @@ xivhotbar_keybinds_job['Base'] = {
   --{'battle 2 12', '', '', '', '', ''},
 
   -- Hotbar #3
-  { 'battle 3 1',  'ma', 'Dia',            'stnpc', 'Dia' },
-  { 'battle 3 1',  'ma', 'Dia II',         'stnpc', 'Dia2' },
-  { 'battle 3 2',  'ma', 'Paralyze',       'stnpc', 'Paralyze' },
-  { 'battle 3 3',  'ma', 'Slow',           'stnpc', 'Slow' },
-  { 'battle 3 4',  'ma', 'Silence',        'stnpc', 'Silence' },
-  { 'battle 3 5',  'ma', 'Gravity',        'stnpc', 'Gravity' },
-  { 'battle 3 6',  'ma', 'Blind',          'stnpc', 'Blind' },
+  -- 1-5 reserved for additional weapon skills
+  { 'battle 3 6',  'ma', 'Impact',         't',     'Impact' },
   { 'battle 3 7',  'ma', 'Bind',           'stnpc', 'Bind' },
   { 'battle 3 8',  'ma', 'Sleep',          'stnpc', 'Sleep1' },
   { 'battle 3 9',  'ma', 'Sleep II',       'stnpc', 'Sleep2' },
-  { 'battle 3 10', 'ma', 'Dispel',         'stnpc', 'Dispel' },
+  { 'battle 3 10', 'ma', 'Dispel',         't',     'Dispel' },
   --------------------------------------------------------------------------------------
-  { 'battle 3 11', 'ma', 'Bio',            'stnpc', 'Bio' },
-  { 'battle 3 11', 'ma', 'Bio II',         'stnpc', 'Bio2' },
+  { 'battle 3 11', 'ma', 'Bio',            't',     'Bio' },
+  { 'battle 3 11', 'ma', 'Bio II',         't',     'Bio2' },
   --------------------------------------------------------------------------------------
-  { 'battle 3 12', 'ma', 'Poison',         'stnpc', 'Poison1' },
-  { 'battle 3 12', 'ma', 'Poison II',      'stnpc', 'Poison2' },
+  { 'battle 3 12', 'ma', 'Poison',         't',     'Poison1' },
+  { 'battle 3 12', 'ma', 'Poison II',      't',     'Poison2' },
+  { 'battle 3 12', 'ma', 'Meteor',         't',     'Meteor' },
   --------------------------------------------------------------------------------------
 
   -- Hotbar #4
   { 'battle 4 1',  'ma', 'Blink',          'me',    'Blink' },
   { 'battle 4 2',  'ma', 'Stoneskin',      'me',    'Stoneskin' },
-  { 'battle 4 3',  'ma', 'Burn',           'stnpc', 'Burn' },
-  { 'battle 4 4',  'ma', 'Frost',          'stnpc', 'Frost' },
-  { 'battle 4 5',  'ma', 'Choke',          'stnpc', 'Choke' },
-  { 'battle 4 6',  'ma', 'Rasp',           'stnpc', 'Rasp' },
-  { 'battle 4 7',  'ma', 'Shock',          'stnpc', 'Shock' },
-  { 'battle 4 8',  'ma', 'Drown',          'stnpc', 'Drown' },
-  { 'battle 4 9',  'ma', 'Drain',          'stnpc', 'Drain' },
-  { 'battle 4 10', 'ma', 'Aspir',          'stnpc', 'Aspir' },
-  { 'battle 4 10', 'ma', 'Aspir II',       'stnpc', 'Aspir2' },
-  { 'battle 4 10', 'ma', 'Aspir III',      'stnpc', 'Aspir3' },
+
+  { 'battle 4 3',  'ma', 'Burn',           't',     'Burn' },
+  { 'battle 4 4',  'ma', 'Frost',          't',     'Frost' },
+  { 'battle 4 5',  'ma', 'Choke',          't',     'Choke' },
+  { 'battle 4 6',  'ma', 'Rasp',           't',     'Rasp' },
+  { 'battle 4 7',  'ma', 'Shock',          't',     'Shock' },
+  { 'battle 4 8',  'ma', 'Drown',          't',     'Drown' },
+
+  { 'battle 4 9',  'ma', 'Drain',          't',     'Drain' },
+  { 'battle 4 10', 'ma', 'Aspir',          't',     'Aspir' },
+  { 'battle 4 10', 'ma', 'Aspir II',       't',     'Aspir2' },
+  { 'battle 4 10', 'ma', 'Aspir III',      't',     'Aspir3' },
   { 'battle 4 11', 'ja', 'Mana Wall',      'me',    'M.Wall' },
   { 'battle 4 12', 'ja', 'Manafont',       'me',    'M.Font',   '2Hr' },
 
   -- Hotbar #5
   --------------------------------------------------------------------------------------
-  { 'battle 5 1',  'ma', 'Stone',          'stnpc', 'Stone' },
-  { 'battle 5 1',  'ma', 'Stone II',       'stnpc', 'Stone2' },
-  { 'battle 5 1',  'ma', 'Stone III',      'stnpc', 'Stone3' },
-  { 'battle 5 1',  'ma', 'Stone IV',       'stnpc', 'Stone4' },
-  { 'battle 5 1',  'ma', 'Stone V',        'stnpc', 'Stone5' },
-  { 'battle 5 1',  'ma', 'Stone VI',       'stnpc', 'Stone6' },
+  { 'battle 5 1',  'ma', 'Stone',          't',     'Stone' },
+  { 'battle 5 1',  'ma', 'Stone II',       't',     'Stone2' },
+  { 'battle 5 1',  'ma', 'Stone III',      't',     'Stone3' },
+  { 'battle 5 1',  'ma', 'Stone IV',       't',     'Stone4' },
+  { 'battle 5 1',  'ma', 'Stone V',        't',     'Stone5' },
+  { 'battle 5 1',  'ma', 'Stone VI',       't',     'Stone6' },
   --------------------------------------------------------------------------------------
-  { 'battle 5 2',  'ma', 'Water',          'stnpc', 'Water' },
-  { 'battle 5 2',  'ma', 'Water II',       'stnpc', 'Water2' },
-  { 'battle 5 2',  'ma', 'Water III',      'stnpc', 'Water3' },
-  { 'battle 5 2',  'ma', 'Water IV',       'stnpc', 'Water4' },
-  { 'battle 5 2',  'ma', 'Water V',        'stnpc', 'Water5' },
-  { 'battle 5 2',  'ma', 'Water VI',       'stnpc', 'Water6' },
+  { 'battle 5 2',  'ma', 'Water',          't',     'Water' },
+  { 'battle 5 2',  'ma', 'Water II',       't',     'Water2' },
+  { 'battle 5 2',  'ma', 'Water III',      't',     'Water3' },
+  { 'battle 5 2',  'ma', 'Water IV',       't',     'Water4' },
+  { 'battle 5 2',  'ma', 'Water V',        't',     'Water5' },
+  { 'battle 5 2',  'ma', 'Water VI',       't',     'Water6' },
   --------------------------------------------------------------------------------------
-  { 'battle 5 3',  'ma', 'Aero',           'stnpc', 'Aero' },
-  { 'battle 5 3',  'ma', 'Aero II',        'stnpc', 'Aero2' },
-  { 'battle 5 3',  'ma', 'Aero III',       'stnpc', 'Aero3' },
-  { 'battle 5 3',  'ma', 'Aero IV',        'stnpc', 'Aero4' },
-  { 'battle 5 3',  'ma', 'Aero V',         'stnpc', 'Aero5' },
-  { 'battle 5 3',  'ma', 'Aero VI',        'stnpc', 'Aero6' },
+  { 'battle 5 3',  'ma', 'Aero',           't',     'Aero' },
+  { 'battle 5 3',  'ma', 'Aero II',        't',     'Aero2' },
+  { 'battle 5 3',  'ma', 'Aero III',       't',     'Aero3' },
+  { 'battle 5 3',  'ma', 'Aero IV',        't',     'Aero4' },
+  { 'battle 5 3',  'ma', 'Aero V',         't',     'Aero5' },
+  { 'battle 5 3',  'ma', 'Aero VI',        't',     'Aero6' },
   --------------------------------------------------------------------------------------
-  { 'battle 5 4',  'ma', 'Fire',           'stnpc', 'Fire' },
-  { 'battle 5 4',  'ma', 'Fire II',        'stnpc', 'Fire2' },
-  { 'battle 5 4',  'ma', 'Fire III',       'stnpc', 'Fire3' },
-  { 'battle 5 4',  'ma', 'Fire IV',        'stnpc', 'Fire4' },
-  { 'battle 5 4',  'ma', 'Fire V',         'stnpc', 'Fire5' },
-  { 'battle 5 4',  'ma', 'Fire VI',        'stnpc', 'Fire6' },
+  { 'battle 5 4',  'ma', 'Fire',           't',     'Fire' },
+  { 'battle 5 4',  'ma', 'Fire II',        't',     'Fire2' },
+  { 'battle 5 4',  'ma', 'Fire III',       't',     'Fire3' },
+  { 'battle 5 4',  'ma', 'Fire IV',        't',     'Fire4' },
+  { 'battle 5 4',  'ma', 'Fire V',         't',     'Fire5' },
+  { 'battle 5 4',  'ma', 'Fire VI',        't',     'Fire6' },
   --------------------------------------------------------------------------------------
-  { 'battle 5 5',  'ma', 'Blizzard',       'stnpc', 'Blizz' },
-  { 'battle 5 5',  'ma', 'Blizzard II',    'stnpc', 'Blizz2' },
-  { 'battle 5 5',  'ma', 'Blizzard III',   'stnpc', 'Blizz3' },
-  { 'battle 5 5',  'ma', 'Blizzard IV',    'stnpc', 'Blizz4' },
-  { 'battle 5 5',  'ma', 'Blizzard V',     'stnpc', 'Blizz5' },
-  { 'battle 5 5',  'ma', 'Blizzard VI',    'stnpc', 'Blizz6' },
+  { 'battle 5 5',  'ma', 'Blizzard',       't',     'Blizz' },
+  { 'battle 5 5',  'ma', 'Blizzard II',    't',     'Blizz2' },
+  { 'battle 5 5',  'ma', 'Blizzard III',   't',     'Blizz3' },
+  { 'battle 5 5',  'ma', 'Blizzard IV',    't',     'Blizz4' },
+  { 'battle 5 5',  'ma', 'Blizzard V',     't',     'Blizz5' },
+  { 'battle 5 5',  'ma', 'Blizzard VI',    't',     'Blizz6' },
   --------------------------------------------------------------------------------------
-  { 'battle 5 6',  'ma', 'Thunder',        'stnpc', 'Thund' },
-  { 'battle 5 6',  'ma', 'Thunder II',     'stnpc', 'Thund2' },
-  { 'battle 5 6',  'ma', 'Thunder III',    'stnpc', 'Thund3' },
-  { 'battle 5 6',  'ma', 'Thunder IV',     'stnpc', 'Thund4' },
-  { 'battle 5 6',  'ma', 'Thunder V',      'stnpc', 'Thund5' },
-  { 'battle 5 6',  'ma', 'Thunder VI',     'stnpc', 'Thund6' },
+  { 'battle 5 6',  'ma', 'Thunder',        't',     'Thund' },
+  { 'battle 5 6',  'ma', 'Thunder II',     't',     'Thund2' },
+  { 'battle 5 6',  'ma', 'Thunder III',    't',     'Thund3' },
+  { 'battle 5 6',  'ma', 'Thunder IV',     't',     'Thund4' },
+  { 'battle 5 6',  'ma', 'Thunder V',      't',     'Thund5' },
+  { 'battle 5 6',  'ma', 'Thunder VI',     't',     'Thund6' },
   --------------------------------------------------------------------------------------
-  { 'battle 5 7',  'ma', 'Stoneja',        'stnpc', 'Stoneja' },
-  --------------------------------------------------------------------------------------
-  { 'battle 5 8',  'ma', 'Waterja',        'stnpc', 'Waterja' },
-  --------------------------------------------------------------------------------------
-  { 'battle 5 9',  'ma', 'Aeroja',         'stnpc', 'Aeroja' },
-  --------------------------------------------------------------------------------------
-  { 'battle 5 10', 'ma', 'Firaja',         'stnpc', 'Firaja' },
-  --------------------------------------------------------------------------------------
-  { 'battle 5 11', 'ma', 'Blizzaja',       'stnpc', 'Blizzaja' },
-  --------------------------------------------------------------------------------------
-  { 'battle 5 12', 'ma', 'Thundaja',       'stnpc', 'Thundaja' },
+  { 'battle 5 7',  'ma', 'Stoneja',        't',     'Stoneja' },
+  { 'battle 5 8',  'ma', 'Waterja',        't',     'Waterja' },
+  { 'battle 5 9',  'ma', 'Aeroja',         't',     'Aeroja' },
+  { 'battle 5 10', 'ma', 'Firaja',         't',     'Firaja' },
+  { 'battle 5 11', 'ma', 'Blizzaja',       't',     'Blizzaja' },
+  { 'battle 5 12', 'ma', 'Thundaja',       't',     'Thundaja' },
   --------------------------------------------------------------------------------------
   -- Hotbar #6
   --------------------------------------------------------------------------------------
-  { 'battle 6 1',  'ma', 'Stonega',        'stnpc', 'Stonega' },
-  { 'battle 6 1',  'ma', 'Stonega II',     'stnpc', 'Stonega2' },
-  { 'battle 6 1',  'ma', 'Stonega III',    'stnpc', 'Stonega3' },
+  { 'battle 6 1',  'ma', 'Stonega',        't',     'Stonega' },
+  { 'battle 6 1',  'ma', 'Stonega II',     't',     'Stonega2' },
+  { 'battle 6 1',  'ma', 'Stonega III',    't',     'Stonega3' },
   --------------------------------------------------------------------------------------
-  { 'battle 6 2',  'ma', 'Waterga',        'stnpc', 'Waterga' },
-  { 'battle 6 2',  'ma', 'Waterga II',     'stnpc', 'Waterga2' },
-  { 'battle 6 2',  'ma', 'Waterga III',    'stnpc', 'Waterga3' },
+  { 'battle 6 2',  'ma', 'Waterga',        't',     'Waterga' },
+  { 'battle 6 2',  'ma', 'Waterga II',     't',     'Waterga2' },
+  { 'battle 6 2',  'ma', 'Waterga III',    't',     'Waterga3' },
   --------------------------------------------------------------------------------------
-  { 'battle 6 3',  'ma', 'Aeroga',         'stnpc', 'Aeroga' },
-  { 'battle 6 3',  'ma', 'Aeroga II',      'stnpc', 'Aeroga2' },
-  { 'battle 6 3',  'ma', 'Aeroga III',     'stnpc', 'Aeroga3' },
+  { 'battle 6 3',  'ma', 'Aeroga',         't',     'Aeroga' },
+  { 'battle 6 3',  'ma', 'Aeroga II',      't',     'Aeroga2' },
+  { 'battle 6 3',  'ma', 'Aeroga III',     't',     'Aeroga3' },
   --------------------------------------------------------------------------------------
-  { 'battle 6 4',  'ma', 'Firaga',         'stnpc', 'Firaga' },
-  { 'battle 6 4',  'ma', 'Firaga II',      'stnpc', 'Firaga2' },
-  { 'battle 6 4',  'ma', 'Firaga III',     'stnpc', 'Firaga3' },
+  { 'battle 6 4',  'ma', 'Firaga',         't',     'Firaga' },
+  { 'battle 6 4',  'ma', 'Firaga II',      't',     'Firaga2' },
+  { 'battle 6 4',  'ma', 'Firaga III',     't',     'Firaga3' },
   --------------------------------------------------------------------------------------
-  { 'battle 6 5',  'ma', 'Blizzaga',       'stnpc', 'Blizzaga' },
-  { 'battle 6 5',  'ma', 'Blizzaga II',    'stnpc', 'Blizzaga2' },
-  { 'battle 6 5',  'ma', 'Blizzaga III',   'stnpc', 'Blizzaga3' },
+  { 'battle 6 5',  'ma', 'Blizzaga',       't',     'Blizzaga' },
+  { 'battle 6 5',  'ma', 'Blizzaga II',    't',     'Blizzaga2' },
+  { 'battle 6 5',  'ma', 'Blizzaga III',   't',     'Blizzaga3' },
   --------------------------------------------------------------------------------------
-  { 'battle 6 6',  'ma', 'Thundaga',       'stnpc', 'Thundaga' },
-  { 'battle 6 6',  'ma', 'Thundaga II',    'stnpc', 'Thundaga2' },
-  { 'battle 6 6',  'ma', 'Thundaga III',   'stnpc', 'Thundaga3' },
+  { 'battle 6 6',  'ma', 'Thundaga',       't',     'Thundaga' },
+  { 'battle 6 6',  'ma', 'Thundaga II',    't',     'Thundaga2' },
+  { 'battle 6 6',  'ma', 'Thundaga III',   't',     'Thundaga3' },
   --------------------------------------------------------------------------------------
-  { 'battle 6 7',  'ma', 'Comet',          'stnpc', 'Comet' },
-  { 'battle 6 8',  'ma', 'Break',          'stnpc', 'Break' },
-  { 'battle 6 9',  'ma', 'Breakga',        'stnpc', 'Breakga' },
-  { 'battle 6 10', 'ma', 'Death',          'stnpc', 'Death' },
+  { 'battle 6 7',  'ma', 'Comet',          't',     'Comet' },
+  { 'battle 6 8',  'ma', 'Break',          't',     'Break' },
+  { 'battle 6 9',  'ma', 'Breakga',        't',     'Breakga' },
+  { 'battle 6 10', 'ma', 'Death',          't',     'Death' },
   { 'battle 6 11', 'ja', 'Manawell',       'stpc',  'M.Well' },
   { 'battle 6 12', 'ja', 'Subtle Sorcery', 'me',    'S.Sorc' },
 }
 
 xivhotbar_keybinds_job['WHM'] = {
   { 'battle 1 1',  'ma', 'Cure',        'stpc', 'Cure 1' },
-  { 'battle 1 1',  'ma', 'Cure II',     'stpc', 'Cure 2' },
   { 'battle 1 1',  'ma', 'Cure III',    'stpc', 'Cure 3' },
-  { 'battle 1 1',  'ma', 'Cure IV',     'stpc', 'Cure 4' },
+
+  { 'battle 2 1',  'ma', 'Cure II',     'stpc', 'Cure 2' },
+  { 'battle 2 1',  'ma', 'Cure IV',     'stpc', 'Cure 4' },
 
   -- Hotbar #2 (ALT 1-0)
-  { 'battle 2 1',  'ma', 'Poisona',     'stpc', 'Poisona' },
-  { 'battle 2 2',  'ma', 'Paralyna',    'stpc', 'Paralyna' },
-  { 'battle 2 3',  'ma', 'Blindna',     'stpc', 'Blindna' },
-  { 'battle 2 4',  'ma', 'Silena',      'stpc', 'Silena' },
-  { 'battle 2 5',  'ma', 'Cursna',      'stpc', 'Cursna' },
-  { 'battle 2 6',  'ma', 'Viruna',      'stpc', 'Viruna' },
-  { 'battle 2 7',  'ma', 'Stona',       'stpc', 'Stona' },
-  { 'battle 2 8',  'ma', 'Erase',       'stpc', 'Erase' },
+  { 'battle 2 2',  'ma', 'Poisona',     'stpc', 'Poisona' },
+  { 'battle 2 3',  'ma', 'Paralyna',    'stpc', 'Paralyna' },
+  { 'battle 2 4',  'ma', 'Blindna',     'stpc', 'Blindna' },
+  { 'battle 2 5',  'ma', 'Silena',      'stpc', 'Silena' },
+  { 'battle 2 6',  'ma', 'Cursna',      'stpc', 'Cursna' },
+  { 'battle 2 7',  'ma', 'Viruna',      'stpc', 'Viruna' },
+  { 'battle 2 8',  'ma', 'Stona',       'stpc', 'Stona' },
+  { 'battle 2 9',  'ma', 'Erase',       'stpc', 'Erase' },
 
-  { 'battle 2 9',  'ja', 'Divine Seal', 'me',   'Div.Seal' },
+  { 'battle 2 10', 'ja', 'Divine Seal', 'me',   'Div.Seal' },
   --------------------------------------------------------------------------------------
-  { 'battle 2 10', 'ma', 'Curaga',      'stpc', 'Curaga' },
-  { 'battle 2 10', 'ma', 'Curaga II',   'stpc', 'Curaga2' },
-  { 'battle 2 10', 'ma', 'Curaga III',  'stpc', 'Curaga3' },
+  { 'battle 2 11', 'ma', 'Curaga',      'stpc', 'Curaga' },
+  { 'battle 2 11', 'ma', 'Curaga II',   'stpc', 'Curaga2' },
+  { 'battle 2 11', 'ma', 'Curaga III',  'stpc', 'Curaga3' },
   --------------------------------------------------------------------------------------
   { 'battle 2 12', 'ma', 'Reraise',     'me',   'Reraise' },
   --------------------------------------------------------------------------------------
@@ -190,26 +184,24 @@ xivhotbar_keybinds_job['WHM'] = {
 xivhotbar_keybinds_job['RDM'] = {
   -- BAR 1
   { 'battle 1 1',  'ma', 'Cure',     'stpc',  'Cure 1' },
-  { 'battle 1 1',  'ma', 'Cure II',  'stpc',  'Cure 2' },
   { 'battle 1 1',  'ma', 'Cure III', 'stpc',  'Cure 3' },
-  { 'battle 1 1',  'ma', 'Cure IV',  'stpc',  'Cure 4' },
+
+  { 'battle 2 1',  'ma', 'Cure II',  'stpc',  'Cure 2' },
+  { 'battle 2 1',  'ma', 'Cure IV',  'stpc',  'Cure 4' },
 
   -- BAR 2
-  { 'battle 2 1',  'ma', 'Refresh',  'stpc',  'Refresh' },
-  { 'battle 2 2',  'ma', 'Haste',    'stpc',  'Haste' },
-  { 'battle 2 3',  'ma', 'Flurry',   'stpc',  'Flurry' },
+  { 'battle 2 2',  'ma', 'Refresh',  'stpc',  'Refresh' },
+  { 'battle 2 3',  'ma', 'Haste',    'stpc',  'Haste' },
   { 'battle 2 4',  'ma', 'Dia',      'stnpc', 'Dia' },
   { 'battle 2 4',  'ma', 'Dia II',   'stnpc', 'Dia2' },
 
   { 'battle 2 5',  'ma', 'Paralyze', 't',     'Paralyze' },
   { 'battle 2 6',  'ma', 'Slow',     't',     'Slow' },
   { 'battle 2 7',  'ma', 'Silence',  'stnpc', 'Silence' },
-  { 'battle 2 8',  'ma', 'Poison',   't',     'Paralyze' },
-  { 'battle 2 9',  'ma', 'Blind',    't',     'Slow' },
-  { 'battle 2 10', 'ma', 'Bind',     'stnpc', 'Bind' },
-  { 'battle 2 11', 'ma', 'Frazzle',  't',     'Frazzle' },
-
-  { 'battle 2 12', 'ma', 'Phalanx',  'me',    'Phalanx' },
+  { 'battle 2 8',  'ma', 'Frazzle',  't',     'Frazzle' },
+  { 'battle 2 9',  'ma', 'Distract', 't',     'Distract' },
+  { 'battle 2 10', 'ma', 'Phalanx',  'me',    'Phalnx' },
+  { 'battle 2 12', 'ja', 'Convert',  'me',    'Convert' },
 }
 
 xivhotbar_keybinds_job['SCH'] = {
@@ -246,12 +238,12 @@ xivhotbar_keybinds_job['SCH'] = {
   { 'battle 3 5',  'ma', 'Klimaform',       'me',   'Klima' },
 
   -- OVERWRITE THE ELEMENTAL DEBUFFS IF SCH
-  { 'battle 4 3',  'me', 'Sandstorm',       'stpc', 'Sand' },
-  { 'battle 4 4',  'me', 'Rainstorm',       'stpc', 'Rain' },
-  { 'battle 4 5',  'me', 'Windstorm',       'stpc', 'Wind' },
-  { 'battle 4 6',  'me', 'Firestorm',       'stpc', 'Fire' },
-  { 'battle 4 7',  'me', 'Hailstorm',       'stpc', 'Hail' },
-  { 'battle 4 8',  'me', 'Thunderstorm',    'stpc', 'Thdr' },
+  { 'battle 4 3',  'me', 'Sandstorm',       'me',   'Sand' },
+  { 'battle 4 4',  'me', 'Rainstorm',       'me',   'Rain' },
+  { 'battle 4 5',  'me', 'Windstorm',       'me',   'Wind' },
+  { 'battle 4 6',  'me', 'Firestorm',       'me',   'Fire' },
+  { 'battle 4 7',  'me', 'Hailstorm',       'me',   'Hail' },
+  { 'battle 4 8',  'me', 'Thunderstorm',    'me',   'Thdr' },
 }
 
 xivhotbar_keybinds_job['Club'] = {
@@ -268,13 +260,32 @@ xivhotbar_keybinds_job['Staff'] = {
   { 'battle 1 11', 'ws', 'Starburst',        't', 'Star' },
   { 'battle 1 11', 'ws', 'Full Swing',       't', 'Full' },
   { 'battle 1 11', 'ws', 'Spirit Taker',     't', 'Spirit' },
-  { 'battle 1 11', 'ws', 'Retribution',      't', 'Retr' },
   { 'battle 1 11', 'ws', 'Shattersoul',      't', 'S.Soul' },
   { 'battle 1 11', 'ws', 'Gate of Tartarus', 't', 'Tarta' },
   { 'battle 1 11', 'ws', 'Vidohunir',        't', 'Vido' },
   { 'battle 1 11', 'ws', 'Myrkr',            't', 'Myrkr' },
   { 'battle 1 11', 'ws', 'Oshala',           't', 'Oshala' },
   { 'battle 1 11', 'ws', 'Tartarus Torpor',  't', 'Torpor' },
+
+  -- Can slot in extra WS in 3:1-5
+  -- Impaction
+  { 'battle 3 1',  'ws', 'Heavy Swing',      't', 'Heavy' },
+  { 'battle 3 1',  'ws', 'Rock Crusher',     't', 'Rock' },
+
+  -- Reverb / Compression
+  { 'battle 3 2',  'ws', 'Starburst',        't', 'Starbrst' },
+  { 'battle 3 2',  'ws', 'Sunburst',         't', 'Sunbrst' },
+  { 'battle 3 2',  'ws', 'Cataclysm',        't', 'Catcylsm' },
+
+  -- Gravitation / Reverb
+  { 'battle 3 3',  'ws', 'Retribution',      't', 'Retrb' },
+
+  -- Liquefaction / Impaction
+  { 'battle 3 4',  'ws', 'Full Swing',       't', 'Full' },
+
+  -- Detonation
+  { 'battle 3 5',  'ws', 'Shell Crusher',    't', 'Shell' },
+  { 'battle 3 5',  'ws', 'Earth Crusher',    't', 'Crusher' },
 }
 
 

--- a/data/Examples/bst.lua
+++ b/data/Examples/bst.lua
@@ -221,8 +221,8 @@ xivhotbar_keybinds_job['DNC'] = {
   { 'battle 4 3',  'ja', 'Healing Waltz',     'stpc',  'Healing',  'ffxiv/dnc/shield_samba' },
   { 'battle 4 12', 'ja', 'Contradance',       'me',    'Contra',   'ffxiv/dnc/tillana' }, -- mastery
   -- Steps
-  { 'battle 4 4',  'ja', 'Quickstep',         'stnpc', 'Quick',    'ffxiv/dnc/en_avant' },
-  { 'battle 4 5',  'ja', 'Box Step',          'stnpc', 'Box',      'ffxiv/dnc/bladeshower' },
+  { 'battle 4 4',  'ja', 'Quickstep',         't',     'Quick',    'ffxiv/dnc/en_avant' },
+  { 'battle 4 5',  'ja', 'Box Step',          't',     'Box',      'ffxiv/dnc/bladeshower' },
   -- {'battle 3 9', 'ja', 'Stutter Step', 'stnpc', 'Stutter','ffxiv/dnc/fountainfall'},
   -- Flourishes
   { 'battle 4 6',  'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
@@ -292,60 +292,52 @@ xivhotbar_keybinds_job['RUN'] = {
 
 -- WEAPONSKILL SETS
 xivhotbar_keybinds_job['Axe'] = {
-  -- Heavy Hit
   { 'battle 2 1',  'ws', 'Avalanche Axe', 't', 'Avlnche' },
-  { 'battle 2 1',  'ws', 'Spinning Axe',  't', 'Spinning' }, -- war drk run bst
-  { 'battle 2 1',  'ws', 'Calamity',      't', 'Calamity' }, -- war bst
-  -- Multi-Hit
-  { 'battle 2 2',  'ws', 'Raging Axe',    't', 'Raging' },
-  { 'battle 2 2',  'ws', 'Rampage',       't', 'Rampage' },
-  { 'battle 2 2',  'ws', 'Decimation',    't', 'Decimate' }, -- war drk bst rng run
-  -- Wind
-  { 'battle 2 3',  'ws', 'Gale Axe',      't', 'Gale' },
-  -- Specials
-  { 'battle 2 4',  'ws', 'Mistral Axe',   't', 'Mistral' },   -- war bst
-  -- Prime #6
-  { 'battle 2 6',  'ws', 'Blitz',         't', 'Blitz' },     -- bst
-  -- Class Specific #7
-  { 'battle 2 7',  'ws', 'Primal Rend',   't', 'Primal' },    -- bst
-  -- Merit Point #8
-  { 'battle 2 8',  'ws', 'Ruinator',      't', 'Ruinator' },  -- war drk bst rng run
-  -- Empyrean (Abyssea only)  #9
-  { 'battle 2 9',  'ws', 'Cloudsplitter', 't', 'Cloudsplt' }, -- war bst
+  { 'battle 2 1',  'ws', 'Ruinator',      't', 'Ruinator' }, -- war drk bst rng run  -- Merit
+
+  { 'battle 2 2',  'ws', 'Spinning Axe',  't', 'Spinning' }, -- war drk run bst
+  { 'battle 2 2',  'ws', 'Primal Rend',   't', 'Primal' },   -- bst   -- Mythic
+
+  { 'battle 2 3',  'ws', 'Calamity',      't', 'Calamity' }, -- war bst
+
+  { 'battle 2 4',  'ws', 'Raging Axe',    't', 'Raging' },
+  { 'battle 2 4',  'ws', 'Blitz',         't', 'Blitz' }, -- bst   -- Prime
+
+  { 'battle 2 5',  'ws', 'Rampage',       't', 'Rampage' },
+
+  { 'battle 2 6',  'ws', 'Decimation',    't', 'Decimate' }, -- war drk bst rng run
+
+  { 'battle 2 7',  'ws', 'Gale Axe',      't', 'Gale' },
+  { 'battle 2 7',  'ws', 'Cloudsplitter', 't', 'Cloudsplt' }, -- war bst  -- Empy
+
+  { 'battle 2 8',  'ws', 'Mistral Axe',   't', 'Mistral' },   -- war bst
+
+  { 'battle 2 9',  'ws', 'Bora Axe',      't', 'Bora' },      -- war drk run bst
+
+  { 'battle 2 10', 'ws', 'Smash Axe',     't', 'Smash' },
+
   -- Relic (only usable with specific weapon equips) #10
-  { 'battle 2 10', 'ws', 'Onslaught',     't', 'Onslaught' }, -- bst relic
-  -- Bind WS #11
-  { 'battle 2 11', 'ws', 'Bora Axe',      't', 'Bora' },      -- war drk run bst
-  -- Bind WS #12
-  { 'battle 2 12', 'ws', 'Smash Axe',     't', 'Smash' },
+  { 'battle 2 11', 'ws', 'Onslaught',     't', 'Onslaught' }, -- bst relic
+
 }
 
 xivhotbar_keybinds_job['Scythe'] = {
   -- Heavy Hit
-  { 'battle 2 1',  'ws', 'Slice',            't', 'Slice' },
-  { 'battle 2 1',  'ws', 'Vorpal Scythe',    't', 'Vorpal' },
-  { 'battle 2 1',  'ws', 'Spiral Hell',      't', 'Spiral' }, -- war drk bst
+  { 'battle 2 1', 'ws', 'Slice',            't', 'Slice' },
+  { 'battle 2 2', 'ws', 'Vorpal Scythe',    't', 'Vorpal' },
+  { 'battle 2 3', 'ws', 'Spiral Hell',      't', 'Spiral' }, -- war drk bst
   -- Multi-Hit
-  { 'battle 2 2',  'ws', 'Cross Reaper',     't', 'Cross' },
-  -- {'battle 1 2', 'ws', 'Insurgency', 't', 'Insurge'}, -- drk
+  { 'battle 2 4', 'ws', 'Cross Reaper',     't', 'Cross' },
   -- Darkness
-  { 'battle 2 3',  'ws', 'Dark Harvest',     't', 'DHvst' },
-  -- {'battle 1 3', 'ws', 'Shadow of Death', 't', 'Shadow'}, -- war drk
-  -- {'battle 1 3', 'ws', 'Infernal Scythe', 't', 'Infernal'}, -- war drk
-  -- Specials
-  -- {'battle 1 4', 'ws', 'Guillotine', 't', 'Guill'}, -- drk
-  -- Prime #6
-  -- {'battle 1 6', 'ws', 'Origin', 't', 'Origin'}, -- drk
+  { 'battle 2 5', 'ws', 'Dark Harvest',     't', 'DHvst' },
   -- Merit Point #8
-  { 'battle 2 8',  'ws', 'Entropy',          't', 'Entropy' }, -- war drk bst
+  { 'battle 2 6', 'ws', 'Entropy',          't', 'Entropy' }, -- war drk bst
   -- Empyrean (Abyssea only)  #9
-  { 'battle 2 9',  'ws', 'Quietus',          't', 'Quietus' },
-  -- Relic (only usable with specific weapon equips) #10
-  -- {'battle 1 10', 'ws', 'Catastrophe', 't', 'Cata'}, -- drk relic
+  { 'battle 2 7', 'ws', 'Quietus',          't', 'Quietus' },
   -- AoE Ws #11
-  { 'battle 2 11', 'ws', 'Spinning Scythe',  't', 'Spinning' },
+  { 'battle 2 8', 'ws', 'Spinning Scythe',  't', 'Spinning' },
   -- Stun WS #12
-  { 'battle 2 12', 'ws', 'Nightmare Scythe', 't', 'Nmare' },
+  { 'battle 2 9', 'ws', 'Nightmare Scythe', 't', 'Nmare' },
 }
 
 return xivhotbar_keybinds_job

--- a/data/Examples/cor.lua
+++ b/data/Examples/cor.lua
@@ -182,12 +182,12 @@ xivhotbar_keybinds_job['RNG'] = {
 }
 
 xivhotbar_keybinds_job['MNK'] = {
-  { 'battle 3 1', 'ja', 'Boost',         'me', 'Boost',  'ffxiv/mnk/riddle_of_fire' },
-  { 'battle 3 2', 'ja', 'Dodge',         'me', 'Dodge',  'ffxiv/mnk/riddle_of_earth' },
-  { 'battle 3 3', 'ja', 'Focus',         'me', 'Focus',  'ffxiv/mnk/riddle_of_wind' },
-  { 'battle 3 4', 'ja', 'Chakra',        'me', 'Chakra', 'ffxiv/mnk/meditation' },
-  { 'battle 3 5', 'ja', 'Chi Blast',     't',  'Chi',    'ffxiv/mnk/elixir_field' },
-  { 'battle 3 6', 'ja', 'Counterstance', 'me', 'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
+  { 'battle 3 1', 'ja', 'Boost',         'me',    'Boost',  'ffxiv/mnk/riddle_of_fire' },
+  { 'battle 3 2', 'ja', 'Dodge',         'me',    'Dodge',  'ffxiv/mnk/riddle_of_earth' },
+  { 'battle 3 3', 'ja', 'Focus',         'me',    'Focus',  'ffxiv/mnk/riddle_of_wind' },
+  { 'battle 3 4', 'ja', 'Chakra',        'me',    'Chakra', 'ffxiv/mnk/meditation' },
+  { 'battle 3 5', 'ja', 'Chi Blast',     'stnpc', 'Chi',    'ffxiv/mnk/elixir_field' },
+  { 'battle 3 6', 'ja', 'Counterstance', 'me',    'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
 }
 
 xivhotbar_keybinds_job['WAR'] = {
@@ -209,8 +209,8 @@ xivhotbar_keybinds_job['THF'] = {
 
 xivhotbar_keybinds_job['NIN'] = {
   -- Shadows
-  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me', 'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
-  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me', 'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
+  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me',    'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
+  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me',    'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
   -- Elements
   -- {'battle 3 7', 'ma', 'Katon: Ni', 'stnpc', 'Katon2','ffxiv/nin/katon'}, -- fire
   -- {'battle 3 7', 'ma', 'Katon: Ichi', 'stnpc', 'Katon','ffxiv/nin/katon'}, -- fire
@@ -225,14 +225,14 @@ xivhotbar_keybinds_job['NIN'] = {
   -- {'battle 3 12', 'ma', 'Raiton: Ni', 'stnpc', 'Raiton2','ffxiv/nin/raiton'}, -- thunder
   -- {'battle 3 12', 'ma', 'Raiton: Ichi', 'stnpc', 'Raiton','ffxiv/nin/raiton'}, -- thunder
   -- Enfeeblement
-  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 't',  'Kura',      'ffxiv/blu/glower' },      -- blind
-  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 't',  'Doku',      'ffxiv/blu/exuviation' },  -- poison
-  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   't',  'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
+  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 'stnpc', 'Kura',      'ffxiv/blu/glower' },      -- blind
+  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 'stnpc', 'Doku',      'ffxiv/blu/exuviation' },  -- poison
+  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   'stnpc', 'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
   -- Stances
-  { 'battle 3 11', 'ja', 'Yonin',          'me', 'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
-  { 'battle 3 12', 'ja', 'Innin',          'me', 'Innin',     'ffxiv/nin/assassinate' }, -- dps
+  { 'battle 3 11', 'ja', 'Yonin',          'me',    'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
+  { 'battle 3 12', 'ja', 'Innin',          'me',    'Innin',     'ffxiv/nin/assassinate' }, -- dps
 }
 
 xivhotbar_keybinds_job['DNC'] = {
@@ -254,7 +254,7 @@ xivhotbar_keybinds_job['DNC'] = {
   -- {'battle 3 9', 'ja', 'Stutter Step', 'stnpc', 'Stutter','ffxiv/dnc/fountainfall'},
   -- Flourishes
   { 'battle 3 12', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
-  { 'battle 3 9',  'ja', 'Violent Flourish',  't',     'Stun',     'ffxiv/dnc/starfall_dance' },
+  { 'battle 3 9',  'ja', 'Violent Flourish',  'stnpc', 'Stun',     'ffxiv/dnc/starfall_dance' },
   { 'battle 3 10', 'ja', 'Reverse Flourish',  'me',    'Reverse',  'ffxiv/dnc/reverse_cascade' },
   { 'battle 3 11', 'ja', 'Building Flourish', 'me',    'Building', 'ffxiv/dnc/flourish' },
   -- Jigs
@@ -275,10 +275,10 @@ xivhotbar_keybinds_job['DRK'] = {
   { 'battle 3 3', 'ja', 'Consume Mana',  'me',    'Consume', 'ffxiv/drk/syphon_strike' },
   { 'battle 3 4', 'ja', 'Weapon Bash',   't',     'Bash',    'ffxiv/drk/shadow_wall' },
   { 'battle 3 5', 'ja', 'Arcane Circle', 'me',    'Arcane',  'ffxiv/drk/salted_earth' },
-  { 'battle 3 6', 'ma', 'Bio',           't',     'Bio' },
-  { 'battle 3 6', 'ma', 'Bio II',        't',     'Bio2' },
-  { 'battle 3 7', 'ma', 'Sleep',         'stnpc', 'Sleep' },
+  { 'battle 3 6', 'ma', 'Bio II',        'stnpc', 'Bio2' },
+  { 'battle 3 6', 'ma', 'Bio',           'stnpc', 'Bio' },
   { 'battle 3 7', 'ma', 'Sleep II',      'stnpc', 'Sleep2' },
+  { 'battle 3 7', 'ma', 'Sleep',         'stnpc', 'Sleep' },
   { 'battle 3 8', 'ma', 'Stun',          't',     'Stun' },
 }
 
@@ -289,8 +289,8 @@ xivhotbar_keybinds_job['WHM'] = {
   -- { 'battle 3 ',  'ma', 'Paralyze',     'stnpc', 'Para' },
   -- { 'battle 3 ',  'ma', 'Slow',         'stnpc', 'Slow' },
   -- { 'battle 3 ',  'ma', 'Silence',      'stnpc', 'Silence' },
-  { 'battle 3 6',  'ma', 'Dia',          't',     'Dia' },
-  { 'battle 3 6',  'ma', 'Dia II',       't',     'Dia II' },
+  { 'battle 3 6',  'ma', 'Dia II',       'stnpc', 'Dia II' },
+  { 'battle 3 6',  'ma', 'Dia',          'stnpc', 'Dia' },
   -- { 'battle 3 ',  'ma', 'Repose',       'stnpc', 'Repose' },
   -- { 'battle 3 ',  'ma', 'Flash',        'stnpc', 'Flash',     'ffxiv/pld/flash' },
   -- { 'battle 3 ',  'ma', 'Aquaveil',     'me',    'Aquaveil' },

--- a/data/Examples/dnc.lua
+++ b/data/Examples/dnc.lua
@@ -21,8 +21,8 @@ xivhotbar_keybinds_job['Base'] = {
   --main job abilities
   -- Flourishes 1
   { 'battle 2 1',  'ja',    'Animated Flourish',  'stnpc', 'Anima',    'ffxiv/dnc/closed_position' }, --voke
-  { 'battle 2 2',  'ja',    'Desperate Flourish', 't',     'Desp',     'ffxiv/role/break' },          -- gravity
-  { 'battle 2 3',  'ja',    'Violent Flourish',   't',     'Violnt',   'ffxiv/drk/unmend' },          -- stun
+  { 'battle 2 2',  'ja',    'Desperate Flourish', 'stnpc', 'Desp',     'ffxiv/role/break' },          -- gravity
+  { 'battle 2 3',  'ja',    'Violent Flourish',   'stnpc', 'Violnt',   'ffxiv/drk/unmend' },          -- stun
   -- Flourishes 2
   { 'battle 2 5',  'ja',    'Reverse Flourish',   'me',    'Revrse',   'ffxiv/dnc/reverse_cascade' },
   { 'battle 2 6',  'ja',    'Building Flourish',  'me',    'Build',    'ffxiv/dnc/flourish' },
@@ -86,12 +86,12 @@ xivhotbar_keybinds_job['THF'] = {
 }
 
 xivhotbar_keybinds_job['MNK'] = {
-  { 'battle 3 1', 'ja', 'Boost',         'me', 'Boost',  'ffxiv/mnk/riddle_of_fire' },
-  { 'battle 3 2', 'ja', 'Dodge',         'me', 'Dodge',  'ffxiv/mnk/riddle_of_earth' },
-  { 'battle 3 3', 'ja', 'Focus',         'me', 'Focus',  'ffxiv/mnk/riddle_of_wind' },
-  { 'battle 3 4', 'ja', 'Chakra',        'me', 'Chakra', 'ffxiv/mnk/meditation' },
-  { 'battle 3 5', 'ja', 'Chi Blast',     't',  'Chi',    'ffxiv/mnk/elixir_field' },
-  { 'battle 3 6', 'ja', 'Counterstance', 'me', 'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
+  { 'battle 3 1', 'ja', 'Boost',         'me',    'Boost',  'ffxiv/mnk/riddle_of_fire' },
+  { 'battle 3 2', 'ja', 'Dodge',         'me',    'Dodge',  'ffxiv/mnk/riddle_of_earth' },
+  { 'battle 3 3', 'ja', 'Focus',         'me',    'Focus',  'ffxiv/mnk/riddle_of_wind' },
+  { 'battle 3 4', 'ja', 'Chakra',        'me',    'Chakra', 'ffxiv/mnk/meditation' },
+  { 'battle 3 5', 'ja', 'Chi Blast',     'stnpc', 'Chi',    'ffxiv/mnk/elixir_field' },
+  { 'battle 3 6', 'ja', 'Counterstance', 'me',    'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
 }
 
 xivhotbar_keybinds_job['WAR'] = {
@@ -129,8 +129,8 @@ xivhotbar_keybinds_job['COR'] = {
 
 xivhotbar_keybinds_job['NIN'] = {
   -- Shadows
-  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me', 'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
-  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me', 'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
+  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me',    'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
+  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me',    'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
   -- Elements
   -- {'battle 3 7', 'ma', 'Katon: Ni', 'stnpc', 'Katon2','ffxiv/nin/katon'}, -- fire
   -- {'battle 3 7', 'ma', 'Katon: Ichi', 'stnpc', 'Katon','ffxiv/nin/katon'}, -- fire
@@ -145,14 +145,14 @@ xivhotbar_keybinds_job['NIN'] = {
   -- {'battle 3 12', 'ma', 'Raiton: Ni', 'stnpc', 'Raiton2','ffxiv/nin/raiton'}, -- thunder
   -- {'battle 3 12', 'ma', 'Raiton: Ichi', 'stnpc', 'Raiton','ffxiv/nin/raiton'}, -- thunder
   -- Enfeeblement
-  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 't',  'Kura',      'ffxiv/blu/glower' },      -- blind
-  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 't',  'Doku',      'ffxiv/blu/exuviation' },  -- poison
-  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   't',  'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
+  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 'stnpc', 'Kura',      'ffxiv/blu/glower' },      -- blind
+  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 'stnpc', 'Doku',      'ffxiv/blu/exuviation' },  -- poison
+  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   'stnpc', 'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
   -- Stances
-  { 'battle 3 11', 'ja', 'Yonin',          'me', 'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
-  { 'battle 3 12', 'ja', 'Innin',          'me', 'Innin',     'ffxiv/nin/assassinate' }, -- dps
+  { 'battle 3 11', 'ja', 'Yonin',          'me',    'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
+  { 'battle 3 12', 'ja', 'Innin',          'me',    'Innin',     'ffxiv/nin/assassinate' }, -- dps
 }
 
 xivhotbar_keybinds_job['DRG'] = {
@@ -168,8 +168,8 @@ xivhotbar_keybinds_job['DRK'] = {
   { 'battle 3 3', 'ja', 'Consume Mana',  'me',    'Consume', 'ffxiv/drk/syphon_strike' },
   { 'battle 3 4', 'ja', 'Weapon Bash',   't',     'Bash',    'ffxiv/drk/shadow_wall' },
   { 'battle 3 5', 'ja', 'Arcane Circle', 'me',    'Arcane',  'ffxiv/drk/salted_earth' },
-  { 'battle 3 6', 'ma', 'Bio',           't',     'Bio',     'ffxiv/sch/bio' },
-  --{ 'battle 3 6', 'ma', 'Bio II',        't', 'Bio2',    'ffxiv/sch/bio_II' },
+  { 'battle 3 6', 'ma', 'Bio',           'stnpc', 'Bio',     'ffxiv/sch/bio' },
+  --{ 'battle 3 6', 'ma', 'Bio II',        'stnpc', 'Bio2',    'ffxiv/sch/bio_II' },
   { 'battle 3 7', 'ma', 'Sleep',         'stnpc', 'Sleep',   'ffxiv/role/sleep' },
   { 'battle 3 7', 'ma', 'Sleep II',      'stnpc', 'Sleep2',  'ffxiv/role/sleep' },
   { 'battle 3 8', 'ma', 'Stun',          't',     'Stun',    'ffxiv/drk/unmend' },

--- a/data/Examples/drg.lua
+++ b/data/Examples/drg.lua
@@ -39,12 +39,12 @@ xivhotbar_keybinds_job['Base'] = {
 -- SUBJOBS
 -- Hotbar #3
 xivhotbar_keybinds_job['MNK'] = {
-  { 'battle 3 1', 'ja', 'Boost',         'me', 'Boost',  'ffxiv/mnk/riddle_of_fire' },
-  { 'battle 3 2', 'ja', 'Dodge',         'me', 'Dodge',  'ffxiv/mnk/riddle_of_earth' },
-  { 'battle 3 3', 'ja', 'Focus',         'me', 'Focus',  'ffxiv/mnk/riddle_of_wind' },
-  { 'battle 3 4', 'ja', 'Chakra',        'me', 'Chakra', 'ffxiv/mnk/meditation' },
-  { 'battle 3 5', 'ja', 'Chi Blast',     't',  'Chi',    'ffxiv/mnk/elixir_field' },
-  { 'battle 3 6', 'ja', 'Counterstance', 'me', 'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
+  { 'battle 3 1', 'ja', 'Boost',         'me',    'Boost',  'ffxiv/mnk/riddle_of_fire' },
+  { 'battle 3 2', 'ja', 'Dodge',         'me',    'Dodge',  'ffxiv/mnk/riddle_of_earth' },
+  { 'battle 3 3', 'ja', 'Focus',         'me',    'Focus',  'ffxiv/mnk/riddle_of_wind' },
+  { 'battle 3 4', 'ja', 'Chakra',        'me',    'Chakra', 'ffxiv/mnk/meditation' },
+  { 'battle 3 5', 'ja', 'Chi Blast',     'stnpc', 'Chi',    'ffxiv/mnk/elixir_field' },
+  { 'battle 3 6', 'ja', 'Counterstance', 'me',    'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
 }
 
 xivhotbar_keybinds_job['WAR'] = {
@@ -91,8 +91,8 @@ xivhotbar_keybinds_job['COR'] = {
 
 xivhotbar_keybinds_job['NIN'] = {
   -- Shadows
-  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me', 'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
-  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me', 'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
+  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me',    'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
+  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me',    'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
   -- Elements
   -- {'battle 3 7', 'ma', 'Katon: Ni', 'stnpc', 'Katon2','ffxiv/nin/katon'}, -- fire
   -- {'battle 3 7', 'ma', 'Katon: Ichi', 'stnpc', 'Katon','ffxiv/nin/katon'}, -- fire
@@ -107,14 +107,14 @@ xivhotbar_keybinds_job['NIN'] = {
   -- {'battle 3 12', 'ma', 'Raiton: Ni', 'stnpc', 'Raiton2','ffxiv/nin/raiton'}, -- thunder
   -- {'battle 3 12', 'ma', 'Raiton: Ichi', 'stnpc', 'Raiton','ffxiv/nin/raiton'}, -- thunder
   -- Enfeeblement
-  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 't',  'Kura',      'ffxiv/blu/glower' },      -- blind
-  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 't',  'Doku',      'ffxiv/blu/exuviation' },  -- poison
-  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   't',  'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
+  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 'stnpc', 'Kura',      'ffxiv/blu/glower' },      -- blind
+  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 'stnpc', 'Doku',      'ffxiv/blu/exuviation' },  -- poison
+  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   'stnpc', 'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
   -- Stances
-  { 'battle 3 11', 'ja', 'Yonin',          'me', 'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
-  { 'battle 3 12', 'ja', 'Innin',          'me', 'Innin',     'ffxiv/nin/assassinate' }, -- dps
+  { 'battle 3 11', 'ja', 'Yonin',          'me',    'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
+  { 'battle 3 12', 'ja', 'Innin',          'me',    'Innin',     'ffxiv/nin/assassinate' }, -- dps
 }
 
 xivhotbar_keybinds_job['DNC'] = {
@@ -131,12 +131,12 @@ xivhotbar_keybinds_job['DNC'] = {
   { 'battle 3 5',  'ja', 'Healing Waltz',     'stpc',  'Healing',  'ffxiv/dnc/shield_samba' },
   { 'battle 3 8',  'ja', 'Contradance',       'me',    'Contra',   'ffxiv/dnc/tillana' }, -- mastery
   -- Steps
-  { 'battle 3 6',  'ja', 'Quickstep',         't',     'Quick',    'ffxiv/dnc/en_avant' },
-  { 'battle 3 7',  'ja', 'Box Step',          't',     'Box',      'ffxiv/dnc/bladeshower' },
+  { 'battle 3 6',  'ja', 'Quickstep',         'stnpc', 'Quick',    'ffxiv/dnc/en_avant' },
+  { 'battle 3 7',  'ja', 'Box Step',          'stnpc', 'Box',      'ffxiv/dnc/bladeshower' },
   -- {'battle 3 9', 'ja', 'Stutter Step', 'stnpc', 'Stutter','ffxiv/dnc/fountainfall'},
   -- Flourishes
   { 'battle 3 12', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
-  { 'battle 3 9',  'ja', 'Violent Flourish',  't',     'Stun',     'ffxiv/dnc/starfall_dance' },
+  { 'battle 3 9',  'ja', 'Violent Flourish',  'stnpc', 'Stun',     'ffxiv/dnc/starfall_dance' },
   { 'battle 3 10', 'ja', 'Reverse Flourish',  'me',    'Reverse',  'ffxiv/dnc/reverse_cascade' },
   { 'battle 3 11', 'ja', 'Building Flourish', 'me',    'Building', 'ffxiv/dnc/flourish' },
   -- Jigs
@@ -159,8 +159,8 @@ xivhotbar_keybinds_job['DRK'] = {
   { 'battle 3 3', 'ja', 'Consume Mana',  'me',    'Consume', 'ffxiv/drk/syphon_strike' },
   { 'battle 3 4', 'ja', 'Weapon Bash',   't',     'Bash',    'ffxiv/drk/shadow_wall' },
   { 'battle 3 5', 'ja', 'Arcane Circle', 'me',    'Arcane',  'ffxiv/drk/salted_earth' },
-  { 'battle 3 6', 'ma', 'Bio',           't',     'Bio' },
-  { 'battle 3 6', 'ma', 'Bio II',        't',     'Bio2' },
+  { 'battle 3 6', 'ma', 'Bio',           'stnpc', 'Bio' },
+  { 'battle 3 6', 'ma', 'Bio II',        'stnpc', 'Bio2' },
   { 'battle 3 7', 'ma', 'Sleep',         'stnpc', 'Sleep' },
   { 'battle 3 7', 'ma', 'Sleep II',      'stnpc', 'Sleep2' },
   { 'battle 3 8', 'ma', 'Stun',          't',     'Stun' },
@@ -168,16 +168,16 @@ xivhotbar_keybinds_job['DRK'] = {
 
 xivhotbar_keybinds_job['WHM'] = {
   -- Abilities
-  { 'battle 3 12', 'ja', 'Divine Seal', 'me',   'Divine',  'ffxiv/whm/divine_benison' },
+  { 'battle 3 12', 'ja', 'Divine Seal', 'me',    'Divine',  'ffxiv/whm/divine_benison' },
   -- Enfeeblement
   -- { 'battle 3 ',  'ma', 'Paralyze',     'stnpc', 'Para' },
   -- { 'battle 3 ',  'ma', 'Slow',         'stnpc', 'Slow' },
   -- { 'battle 3 ',  'ma', 'Silence',      'stnpc', 'Silence' },
-  { 'battle 3 1',  'ma', 'Dia',         't',    'Dia' },
+  { 'battle 3 1',  'ma', 'Dia',         'stnpc', 'Dia' },
   --{ 'battle 3 2',  'ma', 'Dia II',      'stnpc', 'Dia II' },
   -- { 'battle 3 ',  'ma', 'Repose',       'stnpc', 'Repose' },
   -- { 'battle 3 ',  'ma', 'Flash',        'stnpc', 'Flash',     'ffxiv/pld/flash' },
-  { 'battle 3 3',  'ma', 'Aquaveil',    'me',   'Aquaveil' },
+  { 'battle 3 3',  'ma', 'Aquaveil',    'me',    'Aquaveil' },
   -- Barspells
   -- { 'battle 3 ',  'ma', 'Barsleepra',   'me',    'Sleepra',   '' },
   -- { 'battle 3 ',  'ma', 'Barpoisonra',  'me',    'Poisonra',  '' },
@@ -195,61 +195,61 @@ xivhotbar_keybinds_job['WHM'] = {
   -- Atk
   -- { 'battle 3 ',  'ma', 'Holy',         'stnpc', 'Holy' }, -- mastery
   -- Regen
-  { 'battle 3 5',  'ma', 'Regen',       'stpc', 'Regen' },
-  { 'battle 3 5',  'ma', 'Regen II',    'stpc', 'Regen2' },
+  { 'battle 3 5',  'ma', 'Regen',       'stpc',  'Regen' },
+  { 'battle 3 5',  'ma', 'Regen II',    'stpc',  'Regen2' },
   -- Cure
-  { 'battle 3 4',  'ma', 'Cure',        'stpc', 'Cure' },
-  { 'battle 3 4',  'ma', 'Cure II',     'stpc', 'Cure2' },
-  { 'battle 3 4',  'ma', 'Cure III',    'stpc', 'Cure3' },
-  { 'battle 3 4',  'ma', 'Cure IV',     'stpc', 'Cure4' },
+  { 'battle 3 4',  'ma', 'Cure',        'stpc',  'Cure' },
+  { 'battle 3 4',  'ma', 'Cure II',     'stpc',  'Cure2' },
+  { 'battle 3 4',  'ma', 'Cure III',    'stpc',  'Cure3' },
+  { 'battle 3 4',  'ma', 'Cure IV',     'stpc',  'Cure4' },
   -- Cura
   --{ 'battle 1 ',   'ma', 'Cura',        'me',    'Cura' },
   -- Curaga
-  { 'battle 3 6',  'ma', 'Curaga',      'stpc', 'Curaga' },
-  { 'battle 3 6',  'ma', 'Curaga II',   'stpc', 'Curaga2' },
-  { 'battle 3 6',  'ma', 'Curaga III',  'stpc', 'Curaga3' }, -- mastery
+  { 'battle 3 6',  'ma', 'Curaga',      'stpc',  'Curaga' },
+  { 'battle 3 6',  'ma', 'Curaga II',   'stpc',  'Curaga2' },
+  { 'battle 3 6',  'ma', 'Curaga III',  'stpc',  'Curaga3' }, -- mastery
   -- Supportive
-  { 'battle 3 7',  'ma', 'Poisona',     'stpc', 'Poisona' },
-  { 'battle 3 7',  'ma', 'Paralyna',    'stpc', 'Paralyna' },
-  { 'battle 3 7',  'ma', 'Blindna',     'stpc', 'Blindna' },
-  { 'battle 3 7',  'ma', 'Silena',      'stpc', 'Silena' },
-  { 'battle 3 7',  'ma', 'Blink',       'me',   'Blink' },
-  { 'battle 3 7',  'ma', 'Stoneskin',   'me',   'StnSkin' },
-  { 'battle 3 7',  'ma', 'Cursna',      'stpc', 'Cursna' },
-  { 'battle 3 7',  'ma', 'Erase',       'stpc', 'Erase' },
+  { 'battle 3 7',  'ma', 'Poisona',     'stpc',  'Poisona' },
+  { 'battle 3 7',  'ma', 'Paralyna',    'stpc',  'Paralyna' },
+  { 'battle 3 7',  'ma', 'Blindna',     'stpc',  'Blindna' },
+  { 'battle 3 7',  'ma', 'Silena',      'stpc',  'Silena' },
+  { 'battle 3 7',  'ma', 'Blink',       'me',    'Blink' },
+  { 'battle 3 7',  'ma', 'Stoneskin',   'me',    'StnSkin' },
+  { 'battle 3 7',  'ma', 'Cursna',      'stpc',  'Cursna' },
+  { 'battle 3 7',  'ma', 'Erase',       'stpc',  'Erase' },
   -- { 'battle 3 ',  'ma', 'Viruna',       'stpc',  'Viruna' },
   -- { 'battle 3 ',  'ma', 'Stona',        'stpc',  'Stona' },
-  { 'battle 3 10', 'ma', 'Haste',       'stpc', 'Haste' },
-  { 'battle 3 11', 'ma', 'Auspice',     'me',   'Ausp' }, -- mastery
+  { 'battle 3 10', 'ma', 'Haste',       'stpc',  'Haste' },
+  { 'battle 3 11', 'ma', 'Auspice',     'me',    'Ausp' }, -- mastery
 }
 
 -- WEAPONSKILL SETS
 xivhotbar_keybinds_job['Polearm'] = {
   -- Heavy Hit
-  { 'battle 1 1',  'ws',                'Vorpal Thrust',   't', 'Vorpal' },
-  { 'battle 1 1',  'ws',                'Wheeling Thrust', 't', 'Wheel' }, -- drg
+  { 'battle 1 1',  'ws', 'Vorpal Thrust',     't', 'Vorpal' },
+  { 'battle 1 1',  'ws', 'Wheeling Thrust',   't', 'Wheel' },              -- drg
   -- Multi-Hit
-  { 'battle 1 2',  'ws',                'Double Thrust',   't', 'Double' },
-  { 'battle 1 2',  'ws',                'Penta Thrust',    't', 'Penta' },
-  { 'battle 1 2',  'ws',                'Drakesbane',      't', 'Drakes' },
+  { 'battle 1 2',  'ws', 'Double Thrust',     't', 'Double' },
+  { 'battle 1 2',  'ws', 'Penta Thrust',      't', 'Penta' },
+  { 'battle 1 2',  'ws', 'Drakesbane',        't', 'Drakes' },
   -- Thunder
-  { 'battle 1 3',  'ws',                'Thunder Thrust',  't', 'Thunder' },
-  { 'battle 1 3',  'ws',                'Raiden Thrust',   't', 'Raiden' },  -- war pld drg
+  { 'battle 1 3',  'ws', 'Thunder Thrust',    't', 'Thunder' },
+  { 'battle 1 3',  'ws', 'Raiden Thrust',     't', 'Raiden' },               -- war pld drg
   -- Specials
-  { 'battle 1 4',  'ws',                'Skewer',          't', 'Skewer' },  -- drg
-  { 'battle 1 4',  'ws',                'Impulse Drive',   't', 'Impulse' }, -- war sam drg
+  { 'battle 1 4',  'ws', 'Skewer',            't', 'Skewer' },               -- drg
+  { 'battle 1 4',  'ws', 'Impulse Drive',     't', 'Impulse' },              -- war sam drg
   -- Prime #6
-  { 'battle 1 6',  'ws',                'Diarmuid',        't', 'Diarm' },
+  { 'battle 1 6',  'ws', 'Diarmuid',          't', 'Diarm' },
   -- Merit Point #8
-  { 'battle 1 8',  'ws',                'Stardiver',       't', 'Star' },    -- war sam drg
+  { 'battle 1 8',  'ws', 'Stardiver',         't', 'Star' },                -- war sam drg
   -- Empyrean (Abyssea only)  #9
-  { 'battle 1 9',  "Camlann's Torment", 'name',            't', 'Camlann' }, -- drg
+  { 'battle 1 9',  'ws', "Camlann's Torment", 't', 'Camlann' },             -- drg
   -- Relic (only usable with specific weapon equips) #10
-  { 'battle 1 10', 'ws',                'Geirskogul',      't', 'Geirsk' },  -- drg
+  { 'battle 1 10', 'ws', 'Geirskogul',        't', 'Geirsk' },              -- drg
   -- AoE Ws #11
-  { 'battle 1 11', 'Sonic Thrust',      'name',            't', 'Sonic' },   -- war pld drg
+  { 'battle 1 11', 'ws', 'Sonic Thrust',      't', 'Sonic' },               -- war pld drg
   -- Stun WS #12
-  { 'battle 1 12', 'ws',                'Leg Sweep',       't', 'LegSwp' },
+  { 'battle 1 12', 'ws', 'Leg Sweep',         't', 'LegSwp' },
 }
 
 xivhotbar_keybinds_job['Sword'] = {

--- a/data/Examples/drk.lua
+++ b/data/Examples/drk.lua
@@ -20,18 +20,18 @@ xivhotbar_keybinds_job['Base'] = {
 
 
   --Hotbar #4   Auxillary spells
-  { 'battle 4 1',  'ma', 'Bio',              't',     'Bio' },
-  { 'battle 4 1',  'ma', 'Bio II',           't',     'Bio2' },
-  { 'battle 4 2',  'ma', 'Drain',            't',     'Drain' },
-  { 'battle 4 2',  'ma', 'Drain II',         't',     'Drain2' },
-  { 'battle 4 3',  'ma', 'Aspir',            't',     'Aspir' },
-  { 'battle 4 3',  'ma', 'Aspir II',         't',     'Aspir2' },
+  { 'battle 4 1',  'ma', 'Bio',              'stnpc', 'Bio' },
+  { 'battle 4 1',  'ma', 'Bio II',           'stnpc', 'Bio2' },
+  { 'battle 4 2',  'ma', 'Drain',            'stnpc', 'Drain' },
+  { 'battle 4 2',  'ma', 'Drain II',         'stnpc', 'Drain2' },
+  { 'battle 4 3',  'ma', 'Aspir',            'stnpc', 'Aspir' },
+  { 'battle 4 3',  'ma', 'Aspir II',         'stnpc', 'Aspir2' },
   { 'battle 4 4',  'ma', 'Bind',             'stnpc', 'Bind' },
   { 'battle 4 5',  'ma', 'Sleep',            'stnpc', 'Sleep' },
   { 'battle 4 5',  'ma', 'Sleep II',         'stnpc', 'Sleep2' },
-  { 'battle 4 6',  'ma', 'Break',            't',     'Break' },
-  { 'battle 4 7',  'ma', 'Poison',           't',     'Psn' },
-  { 'battle 4 7',  'ma', 'Poison II',        't',     'Psn2' },
+  { 'battle 4 6',  'ma', 'Break',            'stnpc', 'Break' },
+  { 'battle 4 7',  'ma', 'Poison',           'stnpc', 'Psn' },
+  { 'battle 4 7',  'ma', 'Poison II',        'stnpc', 'Psn2' },
   { 'battle 4 8',  'ma', 'Endark',           'me',    'Endark' },
   { 'battle 4 9',  'ma', 'Dread Spikes',     'me',    'Dread' },
   { 'battle 4 10', 'ma', 'Tractor',          'stpc',  'Tractor' },
@@ -118,8 +118,8 @@ xivhotbar_keybinds_job['COR'] = {
 
 xivhotbar_keybinds_job['NIN'] = {
   -- Shadows
-  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me', 'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
-  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me', 'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
+  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me',    'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
+  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me',    'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
   -- Elements
   -- {'battle 3 7', 'ma', 'Katon: Ni', 'stnpc', 'Katon2','ffxiv/nin/katon'}, -- fire
   -- {'battle 3 7', 'ma', 'Katon: Ichi', 'stnpc', 'Katon','ffxiv/nin/katon'}, -- fire
@@ -134,14 +134,14 @@ xivhotbar_keybinds_job['NIN'] = {
   -- {'battle 3 12', 'ma', 'Raiton: Ni', 'stnpc', 'Raiton2','ffxiv/nin/raiton'}, -- thunder
   -- {'battle 3 12', 'ma', 'Raiton: Ichi', 'stnpc', 'Raiton','ffxiv/nin/raiton'}, -- thunder
   -- Enfeeblement
-  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 't',  'Kura',      'ffxiv/blu/glower' },      -- blind
-  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 't',  'Doku',      'ffxiv/blu/exuviation' },  -- poison
-  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   't',  'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
+  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 'stnpc', 'Kura',      'ffxiv/blu/glower' },      -- blind
+  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 'stnpc', 'Doku',      'ffxiv/blu/exuviation' },  -- poison
+  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   'stnpc', 'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
   -- Stances
-  { 'battle 3 11', 'ja', 'Yonin',          'me', 'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
-  { 'battle 3 12', 'ja', 'Innin',          'me', 'Innin',     'ffxiv/nin/assassinate' }, -- dps
+  { 'battle 3 11', 'ja', 'Yonin',          'me',    'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
+  { 'battle 3 12', 'ja', 'Innin',          'me',    'Innin',     'ffxiv/nin/assassinate' }, -- dps
 }
 
 xivhotbar_keybinds_job['DNC'] = {
@@ -158,12 +158,12 @@ xivhotbar_keybinds_job['DNC'] = {
   { 'battle 3 5',  'ja', 'Healing Waltz',     'stpc',  'Healing',  'ffxiv/dnc/shield_samba' },
   { 'battle 3 8',  'ja', 'Contradance',       'me',    'Contra',   'ffxiv/dnc/tillana' }, -- mastery
   -- Steps
-  { 'battle 3 6',  'ja', 'Quickstep',         't',     'Quick',    'ffxiv/dnc/en_avant' },
-  { 'battle 3 7',  'ja', 'Box Step',          't',     'Box',      'ffxiv/dnc/bladeshower' },
+  { 'battle 3 6',  'ja', 'Quickstep',         'stnpc', 'Quick',    'ffxiv/dnc/en_avant' },
+  { 'battle 3 7',  'ja', 'Box Step',          'stnpc', 'Box',      'ffxiv/dnc/bladeshower' },
   -- {'battle 3 9', 'ja', 'Stutter Step', 'stnpc', 'Stutter','ffxiv/dnc/fountainfall'},
   -- Flourishes
   { 'battle 3 12', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
-  { 'battle 3 9',  'ja', 'Violent Flourish',  't',     'Stun',     'ffxiv/dnc/starfall_dance' },
+  { 'battle 3 9',  'ja', 'Violent Flourish',  'stnpc', 'Stun',     'ffxiv/dnc/starfall_dance' },
   { 'battle 3 10', 'ja', 'Reverse Flourish',  'me',    'Reverse',  'ffxiv/dnc/reverse_cascade' },
   { 'battle 3 11', 'ja', 'Building Flourish', 'me',    'Building', 'ffxiv/dnc/flourish' },
   -- Jigs
@@ -188,16 +188,16 @@ xivhotbar_keybinds_job['SAM'] = {
 
 xivhotbar_keybinds_job['WHM'] = {
   -- Abilities
-  { 'battle 3 12', 'ja', 'Divine Seal', 'me',   'Divine',  'ffxiv/whm/divine_benison' },
+  { 'battle 3 12', 'ja', 'Divine Seal', 'me',    'Divine',  'ffxiv/whm/divine_benison' },
   -- Enfeeblement
   -- { 'battle 3 ',  'ma', 'Paralyze',     'stnpc', 'Para' },
   -- { 'battle 3 ',  'ma', 'Slow',         'stnpc', 'Slow' },
   -- { 'battle 3 ',  'ma', 'Silence',      'stnpc', 'Silence' },
-  { 'battle 3 1',  'ma', 'Dia',         't',    'Dia' },
+  { 'battle 3 1',  'ma', 'Dia',         'stnpc', 'Dia' },
   --{ 'battle 3 2',  'ma', 'Dia II',      'stnpc', 'Dia II' },
   -- { 'battle 3 ',  'ma', 'Repose',       'stnpc', 'Repose' },
   -- { 'battle 3 ',  'ma', 'Flash',        'stnpc', 'Flash',     'ffxiv/pld/flash' },
-  { 'battle 3 3',  'ma', 'Aquaveil',    'me',   'Aquaveil' },
+  { 'battle 3 3',  'ma', 'Aquaveil',    'me',    'Aquaveil' },
   -- Barspells
   -- { 'battle 3 ',  'ma', 'Barsleepra',   'me',    'Sleepra',   '' },
   -- { 'battle 3 ',  'ma', 'Barpoisonra',  'me',    'Poisonra',  '' },
@@ -215,32 +215,32 @@ xivhotbar_keybinds_job['WHM'] = {
   -- Atk
   -- { 'battle 3 ',  'ma', 'Holy',         'stnpc', 'Holy' }, -- mastery
   -- Regen
-  { 'battle 3 5',  'ma', 'Regen',       'stpc', 'Regen' },
-  { 'battle 3 5',  'ma', 'Regen II',    'stpc', 'Regen2' },
+  { 'battle 3 5',  'ma', 'Regen',       'stpc',  'Regen' },
+  { 'battle 3 5',  'ma', 'Regen II',    'stpc',  'Regen2' },
   -- Cure
-  { 'battle 3 4',  'ma', 'Cure',        'stpc', 'Cure' },
-  { 'battle 3 4',  'ma', 'Cure II',     'stpc', 'Cure2' },
-  { 'battle 3 4',  'ma', 'Cure III',    'stpc', 'Cure3' },
-  { 'battle 3 4',  'ma', 'Cure IV',     'stpc', 'Cure4' },
+  { 'battle 3 4',  'ma', 'Cure',        'stpc',  'Cure' },
+  { 'battle 3 4',  'ma', 'Cure II',     'stpc',  'Cure2' },
+  { 'battle 3 4',  'ma', 'Cure III',    'stpc',  'Cure3' },
+  { 'battle 3 4',  'ma', 'Cure IV',     'stpc',  'Cure4' },
   -- Cura
   --{ 'battle 1 ',   'ma', 'Cura',        'me',    'Cura' },
   -- Curaga
-  { 'battle 3 6',  'ma', 'Curaga',      'stpc', 'Curaga' },
-  { 'battle 3 6',  'ma', 'Curaga II',   'stpc', 'Curaga2' },
-  { 'battle 3 6',  'ma', 'Curaga III',  'stpc', 'Curaga3' }, -- mastery
+  { 'battle 3 6',  'ma', 'Curaga',      'stpc',  'Curaga' },
+  { 'battle 3 6',  'ma', 'Curaga II',   'stpc',  'Curaga2' },
+  { 'battle 3 6',  'ma', 'Curaga III',  'stpc',  'Curaga3' }, -- mastery
   -- Supportive
-  { 'battle 3 7',  'ma', 'Poisona',     'stpc', 'Poisona' },
-  { 'battle 3 7',  'ma', 'Paralyna',    'stpc', 'Paralyna' },
-  { 'battle 3 7',  'ma', 'Blindna',     'stpc', 'Blindna' },
-  { 'battle 3 7',  'ma', 'Silena',      'stpc', 'Silena' },
-  { 'battle 3 7',  'ma', 'Blink',       'me',   'Blink' },
-  { 'battle 3 7',  'ma', 'Stoneskin',   'me',   'StnSkin' },
-  { 'battle 3 7',  'ma', 'Cursna',      'stpc', 'Cursna' },
-  { 'battle 3 7',  'ma', 'Erase',       'stpc', 'Erase' },
+  { 'battle 3 7',  'ma', 'Poisona',     'stpc',  'Poisona' },
+  { 'battle 3 7',  'ma', 'Paralyna',    'stpc',  'Paralyna' },
+  { 'battle 3 7',  'ma', 'Blindna',     'stpc',  'Blindna' },
+  { 'battle 3 7',  'ma', 'Silena',      'stpc',  'Silena' },
+  { 'battle 3 7',  'ma', 'Blink',       'me',    'Blink' },
+  { 'battle 3 7',  'ma', 'Stoneskin',   'me',    'StnSkin' },
+  { 'battle 3 7',  'ma', 'Cursna',      'stpc',  'Cursna' },
+  { 'battle 3 7',  'ma', 'Erase',       'stpc',  'Erase' },
   -- { 'battle 3 ',  'ma', 'Viruna',       'stpc',  'Viruna' },
   -- { 'battle 3 ',  'ma', 'Stona',        'stpc',  'Stona' },
-  { 'battle 3 10', 'ma', 'Haste',       'stpc', 'Haste' },
-  { 'battle 3 11', 'ma', 'Auspice',     'me',   'Ausp' }, -- mastery
+  { 'battle 3 10', 'ma', 'Haste',       'stpc',  'Haste' },
+  { 'battle 3 11', 'ma', 'Auspice',     'me',    'Ausp' }, -- mastery
 }
 
 xivhotbar_keybinds_job['RDM'] = {

--- a/data/Examples/mnk.lua
+++ b/data/Examples/mnk.lua
@@ -6,13 +6,13 @@ xivhotbar_keybinds_job['Base'] = {
 
   --Hotbar #2
   --main job abilities
-  { 'battle 2 1',  'ja', 'Chi Blast',        't',  'Chi',            'ffxiv/mnk/elixir_field' },
-  { 'battle 2 2',  'ja', 'Boost',            'me', 'Boost',          'ffxiv/mnk/riddle_of_fire' },
-  { 'battle 2 3',  'ja', 'Focus',            'me', 'Focus',          'ffxiv/mnk/riddle_of_wind' },
-  { 'battle 2 4',  'ja', 'Dodge',            'me', 'Dodge',          'ffxiv/mnk/riddle_of_earth' },
-  { 'battle 2 5',  'ja', 'Counterstance',    'me', 'Ctr',            'ffxiv/mnk/arm_of_the_destroyer' },
-  { 'battle 2 6',  'ja', 'Footwork',         'me', 'Footwk',         'ffxiv/mnk/six-sided_star' },
-  { 'battle 2 7',  'ja', 'Perfect Counter',  'me', 'PCtr',           'ffxiv/mnk/perfect_balance' },
+  { 'battle 2 1',  'ja', 'Chi Blast',        'stnpc', 'Chi',            'ffxiv/mnk/elixir_field' },
+  { 'battle 2 2',  'ja', 'Boost',            'me',    'Boost',          'ffxiv/mnk/riddle_of_fire' },
+  { 'battle 2 3',  'ja', 'Focus',            'me',    'Focus',          'ffxiv/mnk/riddle_of_wind' },
+  { 'battle 2 4',  'ja', 'Dodge',            'me',    'Dodge',          'ffxiv/mnk/riddle_of_earth' },
+  { 'battle 2 5',  'ja', 'Counterstance',    'me',    'Ctr',            'ffxiv/mnk/arm_of_the_destroyer' },
+  { 'battle 2 6',  'ja', 'Footwork',         'me',    'Footwk',         'ffxiv/mnk/six-sided_star' },
+  { 'battle 2 7',  'ja', 'Perfect Counter',  'me',    'PCtr',           'ffxiv/mnk/perfect_balance' },
 
   --Hotbar #3
   --sub job abilities; leave blank
@@ -20,12 +20,12 @@ xivhotbar_keybinds_job['Base'] = {
   --Hotbar #4
   --utility or pet bar
   --12 is always 2-hour ability
-  { 'battle 4 1',  'ja', 'Chakra',           'me', 'Chakra',         'ffxiv/mnk/meditation' },
-  { 'battle 4 2',  'ja', 'Mantra',           'me', 'Mantra',         'ffxiv/mnk/mantra' },
-  { 'battle 4 3',  'ja', 'Formless Strikes', 'me', 'Formless',       'ffxiv/mnk/form_shift' },
-  { 'battle 4 4',  'ja', 'Impetus',          'me', 'Impetus',        'ffxiv/mnk/bootshine' },
-  { 'battle 4 4',  'ja', 'Inner Strength',   'me', 'Inner Strength', 'ffxiv/mnk/anatman' },
-  { 'battle 4 12', 'ja', 'Hundred Fists',    'me', 'Hundred F',      'ffxiv/mnk/brotherhood' },
+  { 'battle 4 1',  'ja', 'Chakra',           'me',    'Chakra',         'ffxiv/mnk/meditation' },
+  { 'battle 4 2',  'ja', 'Mantra',           'me',    'Mantra',         'ffxiv/mnk/mantra' },
+  { 'battle 4 3',  'ja', 'Formless Strikes', 'me',    'Formless',       'ffxiv/mnk/form_shift' },
+  { 'battle 4 4',  'ja', 'Impetus',          'me',    'Impetus',        'ffxiv/mnk/bootshine' },
+  { 'battle 4 4',  'ja', 'Inner Strength',   'me',    'Inner Strength', 'ffxiv/mnk/anatman' },
+  { 'battle 4 12', 'ja', 'Hundred Fists',    'me',    'Hundred F',      'ffxiv/mnk/brotherhood' },
 
   -- Hotbar #5
 
@@ -78,8 +78,8 @@ xivhotbar_keybinds_job['COR'] = {
 
 xivhotbar_keybinds_job['NIN'] = {
   -- Shadows
-  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me', 'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
-  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me', 'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
+  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me',    'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
+  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me',    'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
   -- Elements
   -- {'battle 3 7', 'ma', 'Katon: Ni', 'stnpc', 'Katon2','ffxiv/nin/katon'}, -- fire
   -- {'battle 3 7', 'ma', 'Katon: Ichi', 'stnpc', 'Katon','ffxiv/nin/katon'}, -- fire
@@ -94,14 +94,14 @@ xivhotbar_keybinds_job['NIN'] = {
   -- {'battle 3 12', 'ma', 'Raiton: Ni', 'stnpc', 'Raiton2','ffxiv/nin/raiton'}, -- thunder
   -- {'battle 3 12', 'ma', 'Raiton: Ichi', 'stnpc', 'Raiton','ffxiv/nin/raiton'}, -- thunder
   -- Enfeeblement
-  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 't',  'Kura',      'ffxiv/blu/glower' },      -- blind
-  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 't',  'Doku',      'ffxiv/blu/exuviation' },  -- poison
-  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   't',  'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
+  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 'stnpc', 'Kura',      'ffxiv/blu/glower' },      -- blind
+  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 'stnpc', 'Doku',      'ffxiv/blu/exuviation' },  -- poison
+  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   'stnpc', 'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
   -- Stances
-  { 'battle 3 11', 'ja', 'Yonin',          'me', 'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
-  { 'battle 3 12', 'ja', 'Innin',          'me', 'Innin',     'ffxiv/nin/assassinate' }, -- dps
+  { 'battle 3 11', 'ja', 'Yonin',          'me',    'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
+  { 'battle 3 12', 'ja', 'Innin',          'me',    'Innin',     'ffxiv/nin/assassinate' }, -- dps
 }
 
 xivhotbar_keybinds_job['DNC'] = {
@@ -118,12 +118,12 @@ xivhotbar_keybinds_job['DNC'] = {
   { 'battle 3 5',  'ja', 'Healing Waltz',     'stpc',  'Healing',  'ffxiv/dnc/shield_samba' },
   { 'battle 3 8',  'ja', 'Contradance',       'me',    'Contra',   'ffxiv/dnc/tillana' }, -- mastery
   -- Steps
-  { 'battle 3 6',  'ja', 'Quickstep',         't',     'Quick',    'ffxiv/dnc/en_avant' },
-  { 'battle 3 7',  'ja', 'Box Step',          't',     'Box',      'ffxiv/dnc/bladeshower' },
+  { 'battle 3 6',  'ja', 'Quickstep',         'stnpc', 'Quick',    'ffxiv/dnc/en_avant' },
+  { 'battle 3 7',  'ja', 'Box Step',          'stnpc', 'Box',      'ffxiv/dnc/bladeshower' },
   -- {'battle 3 9', 'ja', 'Stutter Step', 'stnpc', 'Stutter','ffxiv/dnc/fountainfall'},
   -- Flourishes
   { 'battle 3 12', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
-  { 'battle 3 9',  'ja', 'Violent Flourish',  't',     'Stun',     'ffxiv/dnc/starfall_dance' },
+  { 'battle 3 9',  'ja', 'Violent Flourish',  'stnpc', 'Stun',     'ffxiv/dnc/starfall_dance' },
   { 'battle 3 10', 'ja', 'Reverse Flourish',  'me',    'Reverse',  'ffxiv/dnc/reverse_cascade' },
   { 'battle 3 11', 'ja', 'Building Flourish', 'me',    'Building', 'ffxiv/dnc/flourish' },
   -- Jigs
@@ -208,9 +208,9 @@ xivhotbar_keybinds_job['Staff'] = {
   { 'battle 1 1',  'ws', 'Full Swing',    't', 'Full' },
   { 'battle 1 1',  'ws', 'Retribution',   't', 'Retrb' }, -- war mnk whm blm pld brd drg smn sch geo
   -- Multi-Hit
-  { 'battle 1 2',  'ws', 'name',          't', 'displayName' },
-  { 'battle 1 2',  'ws', 'name',          't', 'displayName' },
-  { 'battle 1 2',  'ws', 'name',          't', 'displayName' },
+  -- { 'battle 1 2',  'ws', 'name',          't', 'displayName' },
+  -- { 'battle 1 2',  'ws', 'name',          't', 'displayName' },
+  -- { 'battle 1 2',  'ws', 'name',          't', 'displayName' },
   -- Elements
   { 'battle 1 3',  'ws', 'Rock Crusher',  't', 'Rock' },
   { 'battle 1 3',  'ws', 'Starburst',     't', 'Starbrst' },

--- a/data/Examples/nin.lua
+++ b/data/Examples/nin.lua
@@ -69,12 +69,12 @@ xivhotbar_keybinds_job['Base'] = {
 -- SUBJOBS
 -- Hotbar #3
 xivhotbar_keybinds_job['MNK'] = {
-  { 'battle 3 1', 'ja', 'Boost',         'me', 'Boost',  'ffxiv/mnk/riddle_of_fire' },
-  { 'battle 3 2', 'ja', 'Dodge',         'me', 'Dodge',  'ffxiv/mnk/riddle_of_earth' },
-  { 'battle 3 3', 'ja', 'Focus',         'me', 'Focus',  'ffxiv/mnk/riddle_of_wind' },
-  { 'battle 3 4', 'ja', 'Chakra',        'me', 'Chakra', 'ffxiv/mnk/meditation' },
-  { 'battle 3 5', 'ja', 'Chi Blast',     't',  'Chi',    'ffxiv/mnk/elixir_field' },
-  { 'battle 3 6', 'ja', 'Counterstance', 'me', 'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
+  { 'battle 3 1', 'ja', 'Boost',         'me',    'Boost',  'ffxiv/mnk/riddle_of_fire' },
+  { 'battle 3 2', 'ja', 'Dodge',         'me',    'Dodge',  'ffxiv/mnk/riddle_of_earth' },
+  { 'battle 3 3', 'ja', 'Focus',         'me',    'Focus',  'ffxiv/mnk/riddle_of_wind' },
+  { 'battle 3 4', 'ja', 'Chakra',        'me',    'Chakra', 'ffxiv/mnk/meditation' },
+  { 'battle 3 5', 'ja', 'Chi Blast',     'stnpc', 'Chi',    'ffxiv/mnk/elixir_field' },
+  { 'battle 3 6', 'ja', 'Counterstance', 'me',    'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
 }
 
 xivhotbar_keybinds_job['WAR'] = {
@@ -133,8 +133,8 @@ xivhotbar_keybinds_job['DNC'] = {
   { 'battle 3 5',  'ja', 'Healing Waltz',     'stpc',  'Healing',  'ffxiv/dnc/shield_samba' },
   { 'battle 3 8',  'ja', 'Contradance',       'me',    'Contra',   'ffxiv/dnc/tillana' }, -- mastery
   -- Steps
-  { 'battle 3 6',  'ja', 'Quickstep',         'stnpc', 'Quick',    'ffxiv/dnc/en_avant' },
-  { 'battle 3 7',  'ja', 'Box Step',          'stnpc', 'Box',      'ffxiv/dnc/bladeshower' },
+  { 'battle 3 6',  'ja', 'Quickstep',         't',     'Quick',    'ffxiv/dnc/en_avant' },
+  { 'battle 3 7',  'ja', 'Box Step',          't',     'Box',      'ffxiv/dnc/bladeshower' },
   -- {'battle 3 9', 'ja', 'Stutter Step', 'stnpc', 'Stutter','ffxiv/dnc/fountainfall'},
   -- Flourishes
   { 'battle 3 12', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
@@ -159,11 +159,11 @@ xivhotbar_keybinds_job['DRK'] = {
   { 'battle 3 3', 'ja', 'Consume Mana',  'me',    'Consume', 'ffxiv/drk/syphon_strike' },
   { 'battle 3 4', 'ja', 'Weapon Bash',   't',     'Bash',    'ffxiv/drk/shadow_wall' },
   { 'battle 3 5', 'ja', 'Arcane Circle', 'me',    'Arcane',  'ffxiv/drk/salted_earth' },
-  { 'battle 3 6', 'ma', 'Bio',           't',     'Bio' },
-  { 'battle 3 6', 'ma', 'Bio II',        't',     'Bio II' },
+  { 'battle 3 6', 'ma', 'Bio',           'stnpc', 'Bio' },
+  { 'battle 3 6', 'ma', 'Bio II',        'stnpc', 'Bio II' },
   { 'battle 3 7', 'ma', 'Sleep',         'stnpc', 'Sleep' },
   { 'battle 3 7', 'ma', 'Sleep II',      'stnpc', 'Sleep II' },
-  { 'battle 3 8', 'ma', 'Stun',          't',     'Stun' },
+  { 'battle 3 8', 'ma', 'Stun',          'stnpc', 'Stun' },
 }
 
 xivhotbar_keybinds_job['RNG'] = {

--- a/data/Examples/pld.lua
+++ b/data/Examples/pld.lua
@@ -54,8 +54,8 @@ xivhotbar_keybinds_job['DRK'] = {
   { 'battle 3 3', 'ja', 'Consume Mana',  'me',    'Consume', 'ffxiv/drk/syphon_strike' },
   { 'battle 3 4', 'ja', 'Weapon Bash',   't',     'Bash',    'ffxiv/drk/shadow_wall' },
   { 'battle 3 5', 'ja', 'Arcane Circle', 'me',    'Arcane',  'ffxiv/drk/salted_earth' },
-  { 'battle 3 6', 'ma', 'Bio',           't',     'Bio' },
-  { 'battle 3 6', 'ma', 'Bio II',        't',     'Bio2' },
+  { 'battle 3 6', 'ma', 'Bio',           'stnpc', 'Bio' },
+  { 'battle 3 6', 'ma', 'Bio II',        'stnpc', 'Bio2' },
   { 'battle 3 7', 'ma', 'Sleep',         'stnpc', 'Sleep' },
   { 'battle 3 7', 'ma', 'Sleep II',      'stnpc', 'Sleep2' },
   { 'battle 3 8', 'ma', 'Stun',          't',     'Stun' },
@@ -105,7 +105,7 @@ xivhotbar_keybinds_job['DNC'] = {
   { 'battle 3 9',  'ja', 'Stutter Step',      't',     'Stutter',  'ffxiv/dnc/fountainfall' },
   -- Flourishes
   { 'battle 3 10', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
-  { 'battle 3 11', 'ja', 'Violent Flourish',  't',     'Stun',     'ffxiv/dnc/starfall_dance' },
+  { 'battle 3 11', 'ja', 'Violent Flourish',  'stnpc', 'Stun',     'ffxiv/dnc/starfall_dance' },
   { 'battle 3 12', 'ja', 'Reverse Flourish',  'me',    'Reverse',  'ffxiv/dnc/reverse_cascade' },
   { 'battle 3 12', 'ja', 'Building Flourish', 'me',    'Building', 'ffxiv/dnc/flourish' },
   -- Jigs
@@ -114,12 +114,12 @@ xivhotbar_keybinds_job['DNC'] = {
 }
 
 xivhotbar_keybinds_job['MNK'] = {
-  { 'battle 3 1', 'ja', 'Boost',         'me', 'Boost',  'ffxiv/mnk/riddle_of_fire' },
-  { 'battle 3 2', 'ja', 'Dodge',         'me', 'Dodge',  'ffxiv/mnk/riddle_of_earth' },
-  { 'battle 3 3', 'ja', 'Focus',         'me', 'Focus',  'ffxiv/mnk/riddle_of_wind' },
-  { 'battle 3 4', 'ja', 'Chakra',        'me', 'Chakra', 'ffxiv/mnk/meditation' },
-  { 'battle 3 5', 'ja', 'Chi Blast',     't',  'Chi',    'ffxiv/mnk/elixir_field' },
-  { 'battle 3 6', 'ja', 'Counterstance', 'me', 'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
+  { 'battle 3 1', 'ja', 'Boost',         'me',    'Boost',  'ffxiv/mnk/riddle_of_fire' },
+  { 'battle 3 2', 'ja', 'Dodge',         'me',    'Dodge',  'ffxiv/mnk/riddle_of_earth' },
+  { 'battle 3 3', 'ja', 'Focus',         'me',    'Focus',  'ffxiv/mnk/riddle_of_wind' },
+  { 'battle 3 4', 'ja', 'Chakra',        'me',    'Chakra', 'ffxiv/mnk/meditation' },
+  { 'battle 3 5', 'ja', 'Chi Blast',     'stnpc', 'Chi',    'ffxiv/mnk/elixir_field' },
+  { 'battle 3 6', 'ja', 'Counterstance', 'me',    'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
 }
 
 xivhotbar_keybinds_job['THF'] = {
@@ -141,16 +141,16 @@ xivhotbar_keybinds_job['WAR'] = {
 
 xivhotbar_keybinds_job['WHM'] = {
   -- Abilities
-  { 'battle 3 12', 'ja', 'Divine Seal', 'me',   'Divine',  'ffxiv/whm/divine_benison' },
+  { 'battle 3 12', 'ja', 'Divine Seal', 'me',    'Divine',  'ffxiv/whm/divine_benison' },
   -- Enfeeblement
   -- { 'battle 3 ',  'ma', 'Paralyze',     'stnpc', 'Para' },
   -- { 'battle 3 ',  'ma', 'Slow',         'stnpc', 'Slow' },
   -- { 'battle 3 ',  'ma', 'Silence',      'stnpc', 'Silence' },
-  { 'battle 3 1',  'ma', 'Dia',         't',    'Dia' },
+  { 'battle 3 1',  'ma', 'Dia',         'stnpc', 'Dia' },
   --{ 'battle 3 2',  'ma', 'Dia II',      'stnpc', 'Dia II' },
   -- { 'battle 3 ',  'ma', 'Repose',       'stnpc', 'Repose' },
   -- { 'battle 3 ',  'ma', 'Flash',        'stnpc', 'Flash',     'ffxiv/pld/flash' },
-  { 'battle 3 3',  'ma', 'Aquaveil',    'me',   'Aquaveil' },
+  { 'battle 3 3',  'ma', 'Aquaveil',    'me',    'Aquaveil' },
   -- Barspells
   -- { 'battle 3 ',  'ma', 'Barsleepra',   'me',    'Sleepra',   '' },
   -- { 'battle 3 ',  'ma', 'Barpoisonra',  'me',    'Poisonra',  '' },
@@ -168,54 +168,53 @@ xivhotbar_keybinds_job['WHM'] = {
   -- Atk
   -- { 'battle 3 ',  'ma', 'Holy',         'stnpc', 'Holy' }, -- mastery
   -- Regen
-  { 'battle 3 5',  'ma', 'Regen',       'stpc', 'Regen' },
-  { 'battle 3 5',  'ma', 'Regen II',    'stpc', 'Regen2' },
+  { 'battle 3 5',  'ma', 'Regen',       'stpc',  'Regen' },
+  { 'battle 3 5',  'ma', 'Regen II',    'stpc',  'Regen2' },
   -- Cure
-  { 'battle 3 4',  'ma', 'Cure',        'stpc', 'Cure' },
-  { 'battle 3 4',  'ma', 'Cure II',     'stpc', 'Cure2' },
-  { 'battle 3 4',  'ma', 'Cure III',    'stpc', 'Cure3' },
-  { 'battle 3 4',  'ma', 'Cure IV',     'stpc', 'Cure4' },
+  { 'battle 3 4',  'ma', 'Cure',        'stpc',  'Cure' },
+  { 'battle 3 4',  'ma', 'Cure II',     'stpc',  'Cure2' },
+  { 'battle 3 4',  'ma', 'Cure III',    'stpc',  'Cure3' },
+  { 'battle 3 4',  'ma', 'Cure IV',     'stpc',  'Cure4' },
   -- Cura
   --{ 'battle 1 ',   'ma', 'Cura',        'me',    'Cura' },
   -- Curaga
-  { 'battle 3 6',  'ma', 'Curaga',      'stpc', 'Curaga' },
-  { 'battle 3 6',  'ma', 'Curaga II',   'stpc', 'Curaga2' },
-  { 'battle 3 6',  'ma', 'Curaga III',  'stpc', 'Curaga3' }, -- mastery
+  { 'battle 3 6',  'ma', 'Curaga',      'stpc',  'Curaga' },
+  { 'battle 3 6',  'ma', 'Curaga II',   'stpc',  'Curaga2' },
+  { 'battle 3 6',  'ma', 'Curaga III',  'stpc',  'Curaga3' }, -- mastery
   -- Supportive
-  { 'battle 3 7',  'ma', 'Poisona',     'stpc', 'Poisona' },
-  { 'battle 3 7',  'ma', 'Paralyna',    'stpc', 'Paralyna' },
-  { 'battle 3 7',  'ma', 'Blindna',     'stpc', 'Blindna' },
-  { 'battle 3 7',  'ma', 'Silena',      'stpc', 'Silena' },
-  { 'battle 3 7',  'ma', 'Blink',       'me',   'Blink' },
-  { 'battle 3 7',  'ma', 'Stoneskin',   'me',   'StnSkin' },
-  { 'battle 3 7',  'ma', 'Cursna',      'stpc', 'Cursna' },
-  { 'battle 3 7',  'ma', 'Erase',       'stpc', 'Erase' },
+  { 'battle 3 7',  'ma', 'Poisona',     'stpc',  'Poisona' },
+  { 'battle 3 7',  'ma', 'Paralyna',    'stpc',  'Paralyna' },
+  { 'battle 3 7',  'ma', 'Blindna',     'stpc',  'Blindna' },
+  { 'battle 3 7',  'ma', 'Silena',      'stpc',  'Silena' },
+  { 'battle 3 7',  'ma', 'Blink',       'me',    'Blink' },
+  { 'battle 3 7',  'ma', 'Stoneskin',   'me',    'StnSkin' },
+  { 'battle 3 7',  'ma', 'Cursna',      'stpc',  'Cursna' },
+  { 'battle 3 7',  'ma', 'Erase',       'stpc',  'Erase' },
   -- { 'battle 3 ',  'ma', 'Viruna',       'stpc',  'Viruna' },
   -- { 'battle 3 ',  'ma', 'Stona',        'stpc',  'Stona' },
-  { 'battle 3 10', 'ma', 'Haste',       'stpc', 'Haste' },
-  { 'battle 3 11', 'ma', 'Auspice',     'me',   'Ausp' }, -- mastery
+  { 'battle 3 10', 'ma', 'Haste',       'stpc',  'Haste' },
+  { 'battle 3 11', 'ma', 'Auspice',     'me',    'Ausp' }, -- mastery
 }
 
 xivhotbar_keybinds_job['RDM'] = {
-  { 'battle 3 1',  'ma', 'Cure',     'stpc',  'Cure 1' },
-  { 'battle 3 1',  'ma', 'Cure II',  'stpc',  'Cure 2' },
-  { 'battle 3 1',  'ma', 'Cure III', 'stpc',  'Cure 3' },
-  { 'battle 3 1',  'ma', 'Cure IV',  'stpc',  'Cure 4' },
+  { 'battle 3 1',  'ma', 'Cure',      'stpc',  'Cure 1' },
+  { 'battle 3 1',  'ma', 'Cure II',   'stpc',  'Cure 2' },
+  { 'battle 3 1',  'ma', 'Cure III',  'stpc',  'Cure 3' },
+  { 'battle 3 1',  'ma', 'Cure IV',   'stpc',  'Cure 4' },
 
-  { 'battle 3 1',  'ma', 'Refresh',  'stpc',  'Refresh' },
-  { 'battle 3 2',  'ma', 'Haste',    'stpc',  'Haste' },
-  { 'battle 3 3',  'ma', 'Dia',      't',     'Dia' },
+  { 'battle 3 1',  'ma', 'Refresh',   'stpc',  'Refresh' },
+  { 'battle 3 2',  'ma', 'Haste',     'stpc',  'Haste' },
+  { 'battle 3 3',  'ma', 'Dia',       'stnpc', 'Dia' },
   --{ 'battle 3 3',  'ma', 'Dia II',   'stnpc', 'Dia2' },
 
-  { 'battle 3 4',  'ma', 'Paralyze', 't',     'Paralyze' },
-  { 'battle 3 5',  'ma', 'Slow',     't',     'Slow' },
-  { 'battle 3 6',  'ma', 'Silence',  'stnpc', 'Silence' },
-  { 'battle 3 7',  'ma', 'Poison',   't',     'Paralyze' },
-  { 'battle 3 8',  'ma', 'Blind',    't',     'Slow' },
-  { 'battle 3 9',  'ma', 'Bind',     'stnpc', 'Bind' },
-  { 'battle 3 10', 'ma', 'Frazzle',  't',     'Frazzle' },
-
-  { 'battle 3 11', 'ma', 'Phalanx',  'me',    'Phalanx' },
+  { 'battle 3 4',  'ma', 'Paralyze',  't',     'Paralyze' },
+  { 'battle 3 5',  'ma', 'Slow',      't',     'Slow' },
+  { 'battle 3 6',  'ma', 'Silence',   'stnpc', 'Silence' },
+  { 'battle 3 7',  'ma', 'Blind',     't',     'Slow' },
+  { 'battle 3 8',  'ma', 'Bind',      'stnpc', 'Bind' },
+  { 'battle 3 9',  'ma', 'Frazzle',   't',     'Frazzle' },
+  { 'battle 3 10', 'ma', 'Stoneskin', 'me',    'StnSkin' },
+  { 'battle 3 11', 'ma', 'Phalanx',   'me',    'Phalanx' },
 }
 
 -- WEAPONSKILL SETS (3-12)

--- a/data/Examples/pup.lua
+++ b/data/Examples/pup.lua
@@ -38,8 +38,8 @@ xivhotbar_keybinds_job['Base'] = {
 -- SUBJOBS (1-10)
 xivhotbar_keybinds_job['NIN'] = {
   -- Shadows
-  { 'battle 4 1',  'ma', 'Utsusemi: Ichi', 'me', 'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
-  { 'battle 4 2',  'ma', 'Utsusemi: Ni',   'me', 'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
+  { 'battle 4 1',  'ma', 'Utsusemi: Ichi', 'me',    'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
+  { 'battle 4 2',  'ma', 'Utsusemi: Ni',   'me',    'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
   -- Elements
   -- {'battle 3 7', 'ma', 'Katon: Ni', 'stnpc', 'Katon2','ffxiv/nin/katon'}, -- fire
   -- {'battle 3 7', 'ma', 'Katon: Ichi', 'stnpc', 'Katon','ffxiv/nin/katon'}, -- fire
@@ -54,14 +54,14 @@ xivhotbar_keybinds_job['NIN'] = {
   -- {'battle 3 12', 'ma', 'Raiton: Ni', 'stnpc', 'Raiton2','ffxiv/nin/raiton'}, -- thunder
   -- {'battle 3 12', 'ma', 'Raiton: Ichi', 'stnpc', 'Raiton','ffxiv/nin/raiton'}, -- thunder
   -- Enfeeblement
-  -- { 'battle 4 3',  'ma', 'Kurayami: Ichi', 'stnpc', 'Kura',      'ffxiv/blu/glower' },      -- blind
-  -- { 'battle 4 4',  'ma', 'Hojo: Ichi',     't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  -- { 'battle 4 4',  'ma', 'Hojo: Ni',       't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  -- { 'battle 4 5',  'ma', 'Dokumori: Ichi', 'stnpc', 'Doku',      'ffxiv/blu/exuviation' },  -- poison
-  -- { 'battle 4 6',  'ma', 'Jubaku: Ichi',   'stnpc', 'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
+  { 'battle 4 3',  'ma', 'Kurayami: Ichi', 'stnpc', 'Kura',      'ffxiv/blu/glower' },      -- blind
+  { 'battle 4 4',  'ma', 'Hojo: Ichi',     't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 4 4',  'ma', 'Hojo: Ni',       't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 4 5',  'ma', 'Dokumori: Ichi', 'stnpc', 'Doku',      'ffxiv/blu/exuviation' },  -- poison
+  { 'battle 4 6',  'ma', 'Jubaku: Ichi',   'stnpc', 'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
   -- Stances
-  -- { 'battle 4 9',  'ja', 'Yonin',          'me',    'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
-  { 'battle 4 10', 'ja', 'Innin',          'me', 'Innin',     'ffxiv/nin/assassinate' }, -- dps
+  { 'battle 4 9',  'ja', 'Yonin',          'me',    'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
+  { 'battle 4 10', 'ja', 'Innin',          'me',    'Innin',     'ffxiv/nin/assassinate' }, -- dps
 }
 
 xivhotbar_keybinds_job['WAR'] = {
@@ -167,8 +167,8 @@ xivhotbar_keybinds_job['RDM'] = {
   -- { 'battle 3 12', 'ma', 'Enthunder II',  'me',    'Enthun2' },  -- mastery
   -- { 'battle 3 12', 'ma', 'Enthunder',     'me',    'Enthun' },
   --Enfeeblement
-  { 'battle 4 1',  'ma', 'Dia',       't',     'Dia' },
-  { 'battle 4 1',  'ma', 'Dia II',    't',     'Dia2' },
+  { 'battle 4 1',  'ma', 'Dia',       'stnpc', 'Dia' },
+  { 'battle 4 1',  'ma', 'Dia II',    'stnpc', 'Dia2' },
   -- { 'battle 3 ',  'ma', 'Diaga',         'stnpc', 'Diaga' },
   -- { 'battle 3 ',  'ma', 'Poison II',     'stnpc', 'Poison2' },
   -- { 'battle 3 ',  'ma', 'Poison',        'stnpc', 'Poison' },
@@ -230,13 +230,13 @@ xivhotbar_keybinds_job['RDM'] = {
 
 xivhotbar_keybinds_job['WHM'] = {
   -- Abilities
-  { 'battle 4 10', 'ja', 'Divine Seal', 'me',   'Divine',  'ffxiv/whm/divine_benison' },
+  { 'battle 4 10', 'ja', 'Divine Seal', 'me',    'Divine',  'ffxiv/whm/divine_benison' },
   -- Enfeeblement
   -- { 'battle 3 ',  'ma', 'Paralyze',     'stnpc', 'Para' },
   -- { 'battle 3 ',  'ma', 'Slow',         'stnpc', 'Slow' },
   -- { 'battle 3 ',  'ma', 'Silence',      'stnpc', 'Silence' },
-  { 'battle 4 1',  'ma', 'Dia',         't',    'Dia' },
-  { 'battle 4 1',  'ma', 'Dia II',      't',    'Dia II' },
+  { 'battle 4 1',  'ma', 'Dia',         'stnpc', 'Dia' },
+  { 'battle 4 1',  'ma', 'Dia II',      'stnpc', 'Dia II' },
   -- { 'battle 4 9',  'ma', 'Repose',      'stnpc', 'Repose' },
   -- { 'battle 3 ',  'ma', 'Flash',        'stnpc', 'Flash',     'ffxiv/pld/flash' },
   --{ 'battle 4 9',  'ma', 'Aquaveil',    'me',    'Aquaveil' },
@@ -260,27 +260,27 @@ xivhotbar_keybinds_job['WHM'] = {
   -- { 'battle 4 3',  'ma', 'Regen',       'stpc',  'Regen' },
   -- { 'battle 4 3',  'ma', 'Regen II',    'stpc',  'Regen2' },
   -- Cure
-  { 'battle 4 2',  'ma', 'Cure',        'stpc', 'Cure' },
-  { 'battle 4 2',  'ma', 'Cure II',     'stpc', 'Cure2' },
-  { 'battle 4 2',  'ma', 'Cure III',    'stpc', 'Cure3' },
-  { 'battle 4 2',  'ma', 'Cure IV',     'stpc', 'Cure4' },
+  { 'battle 4 2',  'ma', 'Cure',        'stpc',  'Cure' },
+  { 'battle 4 2',  'ma', 'Cure II',     'stpc',  'Cure2' },
+  { 'battle 4 2',  'ma', 'Cure III',    'stpc',  'Cure3' },
+  { 'battle 4 2',  'ma', 'Cure IV',     'stpc',  'Cure4' },
   -- Cura
   -- { 'battle 3 ', 'ma', 'Cura',         'me',    'Cura' },
   -- Curaga
-  { 'battle 4 3',  'ma', 'Curaga',      'stpc', 'Curaga' },
-  { 'battle 4 3',  'ma', 'Curaga II',   'stpc', 'Curaga2' },
-  { 'battle 4 3',  'ma', 'Curaga III',  'stpc', 'Curaga3' }, -- mastery
+  { 'battle 4 3',  'ma', 'Curaga',      'stpc',  'Curaga' },
+  { 'battle 4 3',  'ma', 'Curaga II',   'stpc',  'Curaga2' },
+  { 'battle 4 3',  'ma', 'Curaga III',  'stpc',  'Curaga3' }, -- mastery
   -- Supportive
-  { 'battle 4 3',  'ma', 'Poisona',     'stpc', 'Poisona' },
-  { 'battle 4 4',  'ma', 'Paralyna',    'stpc', 'Paralyna' },
-  { 'battle 4 5',  'ma', 'Blindna',     'stpc', 'Blindna' },
-  { 'battle 4 6',  'ma', 'Silena',      'stpc', 'Silena' },
+  { 'battle 4 3',  'ma', 'Poisona',     'stpc',  'Poisona' },
+  { 'battle 4 4',  'ma', 'Paralyna',    'stpc',  'Paralyna' },
+  { 'battle 4 5',  'ma', 'Blindna',     'stpc',  'Blindna' },
+  { 'battle 4 6',  'ma', 'Silena',      'stpc',  'Silena' },
   -- { 'battle 4 7',  'ma', 'Blink',       'me',    'Blink' },
   -- { 'battle 4 7',  'ma', 'Stoneskin',   'me',    'StnSkin' },
-  { 'battle 4 7',  'ma', 'Cursna',      'stpc', 'Cursna' },
-  { 'battle 4 9',  'ma', 'Erase',       'stpc', 'Erase' },
+  { 'battle 4 7',  'ma', 'Cursna',      'stpc',  'Cursna' },
+  { 'battle 4 9',  'ma', 'Erase',       'stpc',  'Erase' },
   -- { 'battle 3 4',  'ma', 'Viruna',       'stpc',  'Viruna' },
-  { 'battle 4 8',  'ma', 'Stona',       'stpc', 'Stona' },
+  { 'battle 4 8',  'ma', 'Stona',       'stpc',  'Stona' },
   -- { 'battle 4 5',  'ma', 'Haste',       'stpc',  'Haste' },
   -- { 'battle 3 ',  'ma', 'Auspice',      'me',    'Ausp' }, -- mastery
 }
@@ -353,94 +353,23 @@ xivhotbar_keybinds_job['Dark Arts'] = {
   -- { 'battle 3 ', 'ma', 'Thunder II',   'stnpc', 'Thund2' }, -- mastery
   -- Enfeeblement
   -- { 'battle 3 ', 'ma', 'Sleep',        'stnpc', 'Sleep' },
-  { 'battle 4 1', 'ma', 'Dispel',       't',  'Dispel' },
+  { 'battle 4 1', 'ma', 'Dispel',      'stnpc', 'Dispel' },
   -- Buffs
-  -- { 'battle 4 2', 'ma', 'Klimaform',   'me',    'Klima' },
-  { 'battle 4 2', 'ma', 'Blaze Spikes', 'me', 'B. Spikes' },
-  { 'battle 4 2', 'ma', 'Ice Spikes',   'me', 'I. Spikes' }, -- mastery
+  { 'battle 4 2', 'ma', 'Klimaform',   'me',    'Klima' },
+  -- { 'battle 3 ', 'ma', 'Blaze Spikes', 'me',    'B. Spikes' },
+  -- { 'battle 3 ', 'ma', 'Ice Spikes',   'me',    'I. Spikes' }, -- mastery
   -- Helix
   -- { 'battle 4 3', 'ma', 'Geohelix',     'stnpc', 'Geo' },
   -- { 'battle 4 4', 'ma', 'Hydrohelix',   'stnpc', 'Hydro' },
   -- { 'battle 4 5', 'ma', 'Anemohelix',   'stnpc', 'Anemo' },
-  -- { 'battle 4 3', 'ma', 'Pyrohelix',   'stnpc', 'Pyro' },
-  -- { 'battle 4 4', 'ma', 'Cryohelix',   'stnpc', 'Cryo' },
-  -- { 'battle 4 5', 'ma', 'Ionohelix',   'stnpc', 'Iono' },
-  -- { 'battle 4 6', 'ma', 'Noctohelix',  't', 'Nocto' },
-  -- { 'battle 4 7', 'ma', 'Luminohelix', 't', 'Lumino' },
+  { 'battle 4 3', 'ma', 'Pyrohelix',   'stnpc', 'Pyro' },
+  { 'battle 4 4', 'ma', 'Cryohelix',   'stnpc', 'Cryo' },
+  { 'battle 4 5', 'ma', 'Ionohelix',   'stnpc', 'Iono' },
+  { 'battle 4 6', 'ma', 'Noctohelix',  'stnpc', 'Nocto' },
+  { 'battle 4 7', 'ma', 'Luminohelix', 'stnpc', 'Lumino' },
   -- Absorb
   -- { 'battle 3 ', 'ma', 'Drain',        'stnpc', 'Drain' },
   -- { 'battle 3 ', 'ma', 'Aspir',        'stnpc', 'Aspir' },
-}
-
-xivhotbar_keybinds_job['BLM'] = {
-  -- Abilities
-  { 'battle 4 10', 'ja', 'Elemental Seal', 'me',    'E Seal',  'ffxiv/blm/foul' },
-  -- Elemental
-  -- { 'battle 3 2',  'ma', 'Stone',          'stnpc', 'Stone' },
-  -- { 'battle 3 2',  'ma', 'Stone II',       'stnpc', 'Stone2' },
-  -- { 'battle 3 2',  'ma', 'Stone III',      'stnpc', 'Stone3' }, -- mastery
-  -- { 'battle 3 2',  'ma', 'Water',          'stnpc', 'Water' },
-  -- { 'battle 3 2',  'ma', 'Water II',       'stnpc', 'Water2' },
-  -- { 'battle 3 2',  'ma', 'Water III',      'stnpc', 'Water3' }, -- mastery
-  -- { 'battle 3 2',  'ma', 'Aero',           'stnpc', 'Aero' },
-  -- { 'battle 3 2',  'ma', 'Aero II',        'stnpc', 'Aero2' },
-  -- { 'battle 3 2',  'ma', 'Aero III',       'stnpc', 'Aero3' }, -- mastery
-  -- { 'battle 3 2',  'ma', 'Fire',           'stnpc', 'Fire' },
-  -- { 'battle 3 2',  'ma', 'Fire II',        'stnpc', 'Fire2' },
-  -- { 'battle 3 2',  'ma', 'Blizzard',       'stnpc', 'Blizzard' },
-  -- { 'battle 3 2',  'ma', 'Blizzard II',    'stnpc', 'Blizzard2' },
-  -- { 'battle 3 2',  'ma', 'Thunder',        'stnpc', 'Thunder' },
-  -- { 'battle 3 2',  'ma', 'Thunder II',     'stnpc', 'Thunder2' },
-  -- { 'battle 3 2',  'ma', 'Drain',          'stpc',  'Drain' },
-  -- { 'battle 3 2',  'ma', 'Aspir',          'stpc',  'Aspir' },
-  -- Elemental AoE
-  -- { 'battle 3 2',  'ma', 'Stonega',        'stnpc', 'Stga' },
-  -- { 'battle 3 2',  'ma', 'Stonega II',     'stnpc', 'Stga2' },
-  -- { 'battle 3 2',  'ma', 'Waterga',        'stnpc', 'Waga' },
-  -- { 'battle 3 2',  'ma', 'Waterga II',     'stnpc', 'Waga2' },
-  -- { 'battle 3 2',  'ma', 'Aeroga',         'stnpc', 'Aega' },
-  -- { 'battle 3 2',  'ma', 'Aeroga II',      'stnpc', 'Aega2' },
-  -- { 'battle 3 2',  'ma', 'Firaga',         'stnpc', 'Figa' },
-  -- { 'battle 3 2',  'ma', 'Firaga II',      'stnpc', 'Figa2' }, -- mastery
-  -- { 'battle 3 2',  'ma', 'Blizzaga',       'stnpc', 'Blga' },
-  -- { 'battle 3 2',  'ma', 'Blizzaga II',    'stnpc', 'Blga2' }, -- mastery
-  -- { 'battle 3 2',  'ma', 'Thundaga',       'stnpc', 'Thga' },
-  -- Ancient Magic
-  -- { 'battle 3 2',  'ma', 'Freeze',         'stnpc', 'Freeze' },  -- mastery
-  -- { 'battle 3 2',  'ma', 'Tornado',        'stnpc', 'Tornado' }, -- mastery
-  -- { 'battle 3 2',  'ma', 'Quake',          'stnpc', 'Quake' },   -- mastery
-  -- { 'battle 3 2',  'ma', 'Burst',          'stnpc', 'Burst' },   -- mastery
-  -- { 'battle 3 2',  'ma', 'Flood',          'stnpc', 'Flood' },   -- mastery
-  -- Elemental DoTs
-  -- { 'battle 3 10', 'ma', 'Shock',          'stpc',  'Shock' },
-  -- { 'battle 3 5',  'ma', 'Rasp',           'stpc',  'Rasp' },
-  -- { 'battle 3 7',  'ma', 'Frost',          'stpc',  'Frost' },
-  -- { 'battle 3 6',  'ma', 'Choke',          'stpc',  'Choke' },
-  -- { 'battle 3 8',  'ma', 'Burn',           'stpc',  'Burn' },
-  -- { 'battle 3 9',  'ma', 'Drown',          'stpc',  'Drown' },
-  -- Enfeeblement
-  -- { 'battle 3 2',  'ma', 'Poison',         't',     'Poison' },
-  -- { 'battle 3 2',  'ma', 'Poison II',      't',     'Poison2' },
-  -- { 'battle 3 2',  'ma', 'Poisonga',       'stpc',  'Psnga' },
-  -- { 'battle 3 3',  'ma', 'Blind',          't',     'Blind' },
-  { 'battle 4 2',  'ma', 'Bind',           'stnpc', 'Bind' },
-  { 'battle 4 1',  'ma', 'Bio',            't',     'Bio' },
-  { 'battle 4 1',  'ma', 'Bio II',         't',     'Bio2' },
-  -- { 'battle 3 2',  'ma', 'Sleep',          'stnpc', 'Sleep' },
-  -- { 'battle 3 2',  'ma', 'Sleep II',       'stnpc', 'Sleep2' }, -- mastery
-  { 'battle 4 3',  'ma', 'Stun',           't',     'Stun' },
-  { 'battle 4 4',  'ma', 'Sleepga',        'stnpc', 'Sleepga' },
-  { 'battle 4 5',  'ma', 'Sleepga II',     'stnpc', 'Sleepga2' }, -- mastery
-  -- Spikes
-  { 'battle 4 6',  'ma', 'Blaze Spikes',   'me',    'BlzSpk' },
-  { 'battle 4 6',  'ma', 'Ice Spikes',     'me',    'IceSpk' },
-  { 'battle 4 7',  'ma', 'Shock Spikes',   'me',    'ShkSpk' },
-  -- Utility
-  -- { 'battle 3 11', 'ma', 'Tractor',        'stpc',  'Tractor' },
-  -- { 'battle 3 2',  'ma', 'Escape',         'me',    'Escape' },
-  -- { 'battle 3 2',  'ma', 'Warp',           'me',    'Warp' },
-  -- { 'battle 3 2',  'ma', 'Warp II',        'stnc',  'Warp2' },
-  -- { 'battle 3 2',  'ma', 'Retrace',        'stnc',  'Retrace' }, -- mastery
 }
 
 -- WEAPONSKILL SETS

--- a/data/Examples/rdm.lua
+++ b/data/Examples/rdm.lua
@@ -12,6 +12,7 @@ xivhotbar_keybinds_job['Base'] = {
   -- Hotbar #1 Cures, weapon skills
   { 'battle 1 1',  'ma', 'Cure',          'stpc',  'Cure' },
   { 'battle 1 1',  'ma', 'Cure II',       'stpc',  'Cure2' },
+  { 'battle 1 1',  'ma', 'Cure III',      'stpc',  'Cure3' },
   { 'battle 1 2',  'ma', 'Cure III',      'stpc',  'Cure3' },
   { 'battle 1 2',  'ma', 'Cure IV',       'stpc',  'Cure4' },
   { 'battle 1 3',  'ma', 'Refresh',       'stpc',  'Refresh' },
@@ -46,9 +47,9 @@ xivhotbar_keybinds_job['Base'] = {
 
   -- Hotbar #3 (CTRL 1-12)
   -- The Big 3 Debuffs first
-  { 'battle 3 1',  'ma', 'Dia II',        't',     'Dia2' },
-  { 'battle 3 1',  'ma', 'Dia III',       't',     'Dia3' },
-  { 'battle 3 1',  'ma', 'Dia',           't',     'Dia' },
+  { 'battle 3 1',  'ma', 'Dia II',        'stnpc', 'Dia2' },
+  { 'battle 3 1',  'ma', 'Dia III',       'stnpc', 'Dia3' },
+  { 'battle 3 1',  'ma', 'Dia',           'stnpc', 'Dia' },
   { 'battle 3 2',  'ma', 'Frazzle',       't',     'Fzzle' },
   { 'battle 3 2',  'ma', 'Frazzle II',    't',     'Fzzle2' },
   { 'battle 3 2',  'ma', 'Frazzle III',   't',     'Fzzle3' },
@@ -70,7 +71,7 @@ xivhotbar_keybinds_job['Base'] = {
   { 'battle 3 9',  'ma', 'Gravity',       'stnpc', 'Gravity' },
   { 'battle 3 9',  'ma', 'Gravity II',    'stnpc', 'Gravity2' },
   { 'battle 3 10', 'ma', 'Bind',          'stnpc', 'Bind' },
-  { 'battle 3 11', 'ma', 'Dispel',        't',     'Dispel' },
+  { 'battle 3 11', 'ma', 'Dispel',        'stnpc', 'Dispel' },
   { 'battle 3 12', 'ja', 'Stymie',        'me',    'Stymie' },
 
 
@@ -113,31 +114,31 @@ xivhotbar_keybinds_job['Base'] = {
   { 'battle 5 2',  'ma', 'Water III',     't',     'Water3' },
   { 'battle 5 2',  'ma', 'Water IV',      't',     'Water4' },
   { 'battle 5 2',  'ma', 'Water V',       't',     'Water5' },
-  ----------------------------------------------------------------------------------
+  --------------------------------------------------------------------------------------
   { 'battle 5 3',  'ma', 'Aero',          't',     'Aero' },
   { 'battle 5 3',  'ma', 'Aero II',       't',     'Aero2' },
   { 'battle 5 3',  'ma', 'Aero III',      't',     'Aero3' },
   { 'battle 5 3',  'ma', 'Aero IV',       't',     'Aero4' },
   { 'battle 5 3',  'ma', 'Aero V',        't',     'Aero5' },
-  ----------------------------------------------------------------------------------
+  --------------------------------------------------------------------------------------
   { 'battle 5 4',  'ma', 'Fire',          't',     'Fire' },
   { 'battle 5 4',  'ma', 'Fire II',       't',     'Fire2' },
   { 'battle 5 4',  'ma', 'Fire III',      't',     'Fire3' },
   { 'battle 5 4',  'ma', 'Fire IV',       't',     'Fire4' },
   { 'battle 5 4',  'ma', 'Fire V',        't',     'Fire5' },
-  ----------------------------------------------------------------------------------
+  --------------------------------------------------------------------------------------
   { 'battle 5 5',  'ma', 'Blizzard',      't',     'Blizz' },
   { 'battle 5 5',  'ma', 'Blizzard II',   't',     'Blizz2' },
   { 'battle 5 5',  'ma', 'Blizzard III',  't',     'Blizz3' },
   { 'battle 5 5',  'ma', 'Blizzard IV',   't',     'Blizz4' },
   { 'battle 5 5',  'ma', 'Blizzard V',    't',     'Blizz5' },
-  ----------------------------------------------------------------------------------
+  --------------------------------------------------------------------------------------
   { 'battle 5 6',  'ma', 'Thunder',       't',     'Thund' },
   { 'battle 5 6',  'ma', 'Thunder II',    't',     'Thund2' },
   { 'battle 5 6',  'ma', 'Thunder III',   't',     'Thund3' },
   { 'battle 5 6',  'ma', 'Thunder IV',    't',     'Thund4' },
   { 'battle 5 6',  'ma', 'Thunder V',     't',     'Thund5' },
-  ----------------------------------------------------------------------------------
+  --------------------------------------------------------------------------------------
   { 'battle 5 7',  'ma', 'Break',         't',     'Break' },
   -- {'battle 5 8', '', '', '', ''},
   --{'battle 5 9', '', '', '', ''},
@@ -174,11 +175,11 @@ xivhotbar_keybinds_job['Base'] = {
 }
 
 xivhotbar_keybinds_job['BLM'] = {
-  { 'battle 2 1', 'ma', 'Stun',           't',     'Stun' },
-  { 'battle 2 2', 'ma', 'Sleepga',        'stnpc', 'Sleepga' },
-  { 'battle 2 3', 'ma', 'Drain',          't',     'Drain' },
-  { 'battle 2 4', 'ma', 'Aspir',          't',     'Aspir' },
-  { 'battle 2 9', 'ja', 'Elemental Seal', 'me',    'E.Seal' },
+  { 'battle 2 1', 'ma', 'Stun',           't',    'Stun' },
+  { 'battle 2 2', 'ma', 'Sleepga',        'stpc', 'Sleepga' },
+  { 'battle 2 3', 'ma', 'Drain',          'stpc', 'Drain' },
+  { 'battle 2 4', 'ma', 'Aspir',          'stpc', 'Aspir' },
+  { 'battle 2 9', 'ja', 'Elemental Seal', 'me',   'E.Seal' },
 }
 
 xivhotbar_keybinds_job['SCH'] = {
@@ -243,7 +244,7 @@ xivhotbar_keybinds_job['NIN'] = {
   --more sword WS because we have room
   { 'battle 2 3',  'ws', 'Fast Blade',       't',  'Fast' },
   { 'battle 2 4',  'ws', 'Spirits Within',   't',  'Spirits' },
-  { 'battle 2 5',  'ws', 'Vorpal Blade',     't',  'Vorpal' },   -- war rdm pld drk blu run
+  { 'battle 2 5',  'ws', 'Circle Blade',     't',  'Circle' },   -- war rdm pld drk blu run
   { 'battle 2 6',  'ws', 'Savage Blade',     't',  'Savage' },   -- war rdm pld drk blu cor run
   { 'battle 2 7',  'ws', 'Sanguine Blade',   't',  'Sanguine' }, -- war rdm pld drk blu run
   { 'battle 2 8',  'ws', 'Imperator',        't',  'Imperator' },
@@ -334,8 +335,8 @@ xivhotbar_keybinds_job['DNC'] = {
   { 'battle 2 5',  'ja', 'Healing Waltz',     'stpc',  'Healing',  'ffxiv/dnc/shield_samba' },
   { 'battle 2 8',  'ja', 'Contradance',       'me',    'Contra',   'ffxiv/dnc/tillana' }, -- mastery
   -- Steps
-  { 'battle 2 6',  'ja', 'Quickstep',         'stnpc', 'Quick',    'ffxiv/dnc/en_avant' },
-  { 'battle 2 7',  'ja', 'Box Step',          'stnpc', 'Box',      'ffxiv/dnc/bladeshower' },
+  { 'battle 2 6',  'ja', 'Quickstep',         't',     'Quick',    'ffxiv/dnc/en_avant' },
+  { 'battle 2 7',  'ja', 'Box Step',          't',     'Box',      'ffxiv/dnc/bladeshower' },
   -- {'battle 3 9', 'ja', 'Stutter Step', 'stnpc', 'Stutter','ffxiv/dnc/fountainfall'},
   -- Flourishes
   { 'battle 2 12', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },

--- a/data/Examples/rng.lua
+++ b/data/Examples/rng.lua
@@ -39,12 +39,12 @@ xivhotbar_keybinds_job['Base'] = {
 -- SUBJOBS
 -- Hotbar #3
 xivhotbar_keybinds_job['MNK'] = {
-  { 'battle 3 1', 'ja', 'Boost',         'me', 'Boost',  'ffxiv/mnk/riddle_of_fire' },
-  { 'battle 3 2', 'ja', 'Dodge',         'me', 'Dodge',  'ffxiv/mnk/riddle_of_earth' },
-  { 'battle 3 3', 'ja', 'Focus',         'me', 'Focus',  'ffxiv/mnk/riddle_of_wind' },
-  { 'battle 3 4', 'ja', 'Chakra',        'me', 'Chakra', 'ffxiv/mnk/meditation' },
-  { 'battle 3 5', 'ja', 'Chi Blast',     't',  'Chi',    'ffxiv/mnk/elixir_field' },
-  { 'battle 3 6', 'ja', 'Counterstance', 'me', 'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
+  { 'battle 3 1', 'ja', 'Boost',         'me',    'Boost',  'ffxiv/mnk/riddle_of_fire' },
+  { 'battle 3 2', 'ja', 'Dodge',         'me',    'Dodge',  'ffxiv/mnk/riddle_of_earth' },
+  { 'battle 3 3', 'ja', 'Focus',         'me',    'Focus',  'ffxiv/mnk/riddle_of_wind' },
+  { 'battle 3 4', 'ja', 'Chakra',        'me',    'Chakra', 'ffxiv/mnk/meditation' },
+  { 'battle 3 5', 'ja', 'Chi Blast',     'stnpc', 'Chi',    'ffxiv/mnk/elixir_field' },
+  { 'battle 3 6', 'ja', 'Counterstance', 'me',    'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
 }
 
 xivhotbar_keybinds_job['WAR'] = {
@@ -91,8 +91,8 @@ xivhotbar_keybinds_job['COR'] = {
 
 xivhotbar_keybinds_job['NIN'] = {
   -- Shadows
-  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me', 'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
-  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me', 'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
+  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me',    'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
+  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me',    'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
   -- Elements
   -- {'battle 3 7', 'ma', 'Katon: Ni', 'stnpc', 'Katon2','ffxiv/nin/katon'}, -- fire
   -- {'battle 3 7', 'ma', 'Katon: Ichi', 'stnpc', 'Katon','ffxiv/nin/katon'}, -- fire
@@ -107,14 +107,14 @@ xivhotbar_keybinds_job['NIN'] = {
   -- {'battle 3 12', 'ma', 'Raiton: Ni', 'stnpc', 'Raiton2','ffxiv/nin/raiton'}, -- thunder
   -- {'battle 3 12', 'ma', 'Raiton: Ichi', 'stnpc', 'Raiton','ffxiv/nin/raiton'}, -- thunder
   -- Enfeeblement
-  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 't',  'Kura',      'ffxiv/blu/glower' },      -- blind
-  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 't',  'Doku',      'ffxiv/blu/exuviation' },  -- poison
-  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   't',  'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
+  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 'stnpc', 'Kura',      'ffxiv/blu/glower' },      -- blind
+  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 'stnpc', 'Doku',      'ffxiv/blu/exuviation' },  -- poison
+  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   'stnpc', 'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
   -- Stances
-  { 'battle 3 11', 'ja', 'Yonin',          'me', 'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
-  { 'battle 3 12', 'ja', 'Innin',          'me', 'Innin',     'ffxiv/nin/assassinate' }, -- dps
+  { 'battle 3 11', 'ja', 'Yonin',          'me',    'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
+  { 'battle 3 12', 'ja', 'Innin',          'me',    'Innin',     'ffxiv/nin/assassinate' }, -- dps
 }
 
 xivhotbar_keybinds_job['DNC'] = {
@@ -136,7 +136,7 @@ xivhotbar_keybinds_job['DNC'] = {
   -- {'battle 3 9', 'ja', 'Stutter Step', 'stnpc', 'Stutter','ffxiv/dnc/fountainfall'},
   -- Flourishes
   { 'battle 3 12', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
-  { 'battle 3 9',  'ja', 'Violent Flourish',  't',     'Stun',     'ffxiv/dnc/starfall_dance' },
+  { 'battle 3 9',  'ja', 'Violent Flourish',  'stnpc', 'Stun',     'ffxiv/dnc/starfall_dance' },
   { 'battle 3 10', 'ja', 'Reverse Flourish',  'me',    'Reverse',  'ffxiv/dnc/reverse_cascade' },
   { 'battle 3 11', 'ja', 'Building Flourish', 'me',    'Building', 'ffxiv/dnc/flourish' },
   -- Jigs
@@ -166,8 +166,8 @@ xivhotbar_keybinds_job['DRK'] = {
   { 'battle 3 3', 'ja', 'Consume Mana',  'me',    'Consume', 'ffxiv/drk/syphon_strike' },
   { 'battle 3 4', 'ja', 'Weapon Bash',   't',     'Bash',    'ffxiv/drk/shadow_wall' },
   { 'battle 3 5', 'ja', 'Arcane Circle', 'me',    'Arcane',  'ffxiv/drk/salted_earth' },
-  { 'battle 3 6', 'ma', 'Bio',           't',     'Bio' },
-  { 'battle 3 6', 'ma', 'Bio II',        't',     'Bio2' },
+  { 'battle 3 6', 'ma', 'Bio',           'stnpc', 'Bio' },
+  { 'battle 3 6', 'ma', 'Bio II',        'stnpc', 'Bio2' },
   { 'battle 3 7', 'ma', 'Sleep',         'stnpc', 'Sleep' },
   { 'battle 3 7', 'ma', 'Sleep II',      'stnpc', 'Sleep2' },
   { 'battle 3 8', 'ma', 'Stun',          't',     'Stun' },

--- a/data/Examples/run.lua
+++ b/data/Examples/run.lua
@@ -3,35 +3,35 @@ xivhotbar_keybinds_job['Base'] = {
   --Hotbar #1
   -- 9-12 Weaponskills;
   -- 1-8 Runes
-  { 'battle 1 1',  'ja', 'Ignis',              'me',   'Ignis',     'ffxiv/pic/fire_in_red' },
-  { 'battle 1 2',  'ja', 'Gelus',              'me',   'Gelus',     'ffxiv/pic/blizzard_in_cyan' },
-  { 'battle 1 3',  'ja', 'Flabra',             'me',   'Flabra',    'ffxiv/pic/aero_in_green' },
-  { 'battle 1 4',  'ja', 'Tellus',             'me',   'Tellus',    'ffxiv/pic/stone_in_yellow' },
-  { 'battle 1 5',  'ja', 'Sulpor',             'me',   'Sulpor',    'ffxiv/pic/thunder_in_magenta' },
-  { 'battle 1 6',  'ja', 'Unda',               'me',   'Unda',      'ffxiv/pic/water_in_blue' },
-  { 'battle 1 7',  'ja', 'Lux',                'me',   'Lux',       'ffxiv/pic/holy_in_white' },
-  { 'battle 1 8',  'ja', 'Tenebrae',           'me',   'Ignis',     'ffxiv/pic/comet_in_black' },
+  { 'battle 1 1',  'ja', 'Ignis',              'me',    'Ignis',     'ffxiv/pic/fire_in_red' },
+  { 'battle 1 2',  'ja', 'Gelus',              'me',    'Gelus',     'ffxiv/pic/blizzard_in_cyan' },
+  { 'battle 1 3',  'ja', 'Flabra',             'me',    'Flabra',    'ffxiv/pic/aero_in_green' },
+  { 'battle 1 4',  'ja', 'Tellus',             'me',    'Tellus',    'ffxiv/pic/stone_in_yellow' },
+  { 'battle 1 5',  'ja', 'Sulpor',             'me',    'Sulpor',    'ffxiv/pic/thunder_in_magenta' },
+  { 'battle 1 6',  'ja', 'Unda',               'me',    'Unda',      'ffxiv/pic/water_in_blue' },
+  { 'battle 1 7',  'ja', 'Lux',                'me',    'Lux',       'ffxiv/pic/holy_in_white' },
+  { 'battle 1 8',  'ja', 'Tenebrae',           'me',    'Ignis',     'ffxiv/pic/comet_in_black' },
 
   -- Hotbar #2
   --main job abilities
   -- Offensive
-  { 'battle 2 1',  'ja', 'Swipe',              't',    'Swipe',     'ffxiv/vpr/First_Generation' },
-  { 'battle 2 2',  'ja', 'Lunge',              't',    'Lunge',     'ffxiv/vpr/Hindsbane_Fang' },
-  { 'battle 2 3',  'ja', 'Gambit',             't',    'Gambit',    'ffxiv/vpr/Twinfang_Bite' },
-  { 'battle 2 4',  'ja', 'Rayke',              'me',   'Rayke',     'ffxiv/vpr/Vicepit' }, -- merit
+  { 'battle 2 1',  'ja', 'Swipe',              't',     'Swipe',     'ffxiv/vpr/First_Generation' },
+  { 'battle 2 2',  'ja', 'Lunge',              't',     'Lunge',     'ffxiv/vpr/Hindsbane_Fang' },
+  { 'battle 2 3',  'ja', 'Gambit',             't',     'Gambit',    'ffxiv/vpr/Twinfang_Bite' },
+  { 'battle 2 4',  'ja', 'Rayke',              'me',    'Rayke',     'ffxiv/vpr/Vicepit' }, -- merit
   -- Defensive Spells
-  { 'battle 2 5',  'ma', 'Blink',              'me',   'Blink' },
-  { 'battle 2 6',  'ma', 'Stoneskin',          'me',   'Stoneskin' },
-  { 'battle 2 7',  'ma', 'Phalanx',            'me',   'Phalanx' },
-  { 'battle 2 8',  'ma', 'Temper',             'me',   'Temper' }, -- job point
+  { 'battle 2 5',  'ma', 'Blink',              'me',    'Blink' },
+  { 'battle 2 6',  'ma', 'Stoneskin',          'me',    'Stoneskin' },
+  { 'battle 2 7',  'ma', 'Phalanx',            'me',    'Phalanx' },
+  { 'battle 2 8',  'ma', 'Temper',             'me',    'Temper' }, -- job point
   -- Curative Spells
-  { 'battle 2 9',  'ma', 'Regen',              'stpc', 'Regen' },
-  { 'battle 2 9',  'ma', 'Regen II',           'stpc', 'Regen2' },
-  { 'battle 2 9',  'ma', 'Regen III',          'stpc', 'Regen3' },
-  { 'battle 2 9',  'ma', 'Regen IV',           'stpc', 'Regen4' },
-  { 'battle 2 10', 'ma', 'Refresh',            'stpc', 'Refresh' },
+  { 'battle 2 9',  'ma', 'Regen',              'stpc',  'Regen' },
+  { 'battle 2 9',  'ma', 'Regen II',           'stpc',  'Regen2' },
+  { 'battle 2 9',  'ma', 'Regen III',          'stpc',  'Regen3' },
+  { 'battle 2 9',  'ma', 'Regen IV',           'stpc',  'Regen4' },
+  { 'battle 2 10', 'ma', 'Refresh',            'stpc',  'Refresh' },
   -- Spell buffs
-  { 'battle 2 12', 'ja', 'Embolden',           'me',   'Embold',    'ffxiv/vpr/Uncoiled_Fury' },
+  { 'battle 2 12', 'ja', 'Embolden',           'me',    'Embold',    'ffxiv/vpr/Uncoiled_Fury' },
 
   --Hotbar #3
   --sub job abilities; leave blank
@@ -40,46 +40,46 @@ xivhotbar_keybinds_job['Base'] = {
   --utility or pet bar
   --12 is always 2-hour ability
   -- Tanking / Self-Targeted Defense
-  { 'battle 4 1',  'ja', 'Vallation',          'me',   'Valltn',    'ffxiv/sge/haima' },
-  { 'battle 4 2',  'ja', 'Swordplay',          'me',   'Swordply',  'ffxiv/vpr/Flanksbane_Fang' },
-  { 'battle 4 3',  'ja', 'Pflug',              'me',   'Pflug',     'ffxiv/sge/eukrasia' },
-  { 'battle 4 4',  'ja', 'Vivacious Pulse',    'me',   'Viva',      'ffxiv/sge/krasis' },
-  { 'battle 4 5',  'ja', 'Battuta',            'me',   'Battuta',   'ffxiv/vpr/Twinblood_Bite' }, -- merit
-  { 'battle 4 6',  'ja', 'Liement',            'me',   'Liement',   'ffxiv/sge/physis' },
+  { 'battle 4 1',  'ja', 'Vallation',          'me',    'Valltn',    'ffxiv/sge/haima' },
+  { 'battle 4 2',  'ja', 'Swordplay',          'me',    'Swordply',  'ffxiv/vpr/Flanksbane_Fang' },
+  { 'battle 4 3',  'ja', 'Pflug',              'me',    'Pflug',     'ffxiv/sge/eukrasia' },
+  { 'battle 4 4',  'ja', 'Vivacious Pulse',    'me',    'Viva',      'ffxiv/sge/krasis' },
+  { 'battle 4 5',  'ja', 'Battuta',            'me',    'Battuta',   'ffxiv/vpr/Twinblood_Bite' }, -- merit
+  { 'battle 4 6',  'ja', 'Liement',            'me',    'Liement',   'ffxiv/sge/physis' },
   -- Party-Wide Defense
-  { 'battle 4 7',  'ja', 'Valiance',           'me',   'Valia',     'ffxiv/sge/panhaima' },
-  { 'battle 4 8',  'ja', 'One for All',        'me',   '1FAll',     'ffxiv/sge/kerachole' },
-  { 'battle 4 11', 'ja', 'Odyllic Subterfuge', 't',    'Odyllic',   'ffxiv/sge/eukrasian_dosis' },
-  { 'battle 4 12', 'ja', 'Elemental Sforzo',   'me',   'Sforzo',    'ffxiv/sge/taurochole' },
+  { 'battle 4 7',  'ja', 'Valiance',           'me',    'Valia',     'ffxiv/sge/panhaima' },
+  { 'battle 4 8',  'ja', 'One for All',        'me',    '1FAll',     'ffxiv/sge/kerachole' },
+  { 'battle 4 11', 'ja', 'Odyllic Subterfuge', 't',     'Odyllic',   'ffxiv/sge/eukrasian_dosis' },
+  { 'battle 4 12', 'ja', 'Elemental Sforzo',   'me',    'Sforzo',    'ffxiv/sge/taurochole' },
 
   -- Hotbar #5
   -- Tanking spells
-  { 'battle 5 1',  'ma', 'Flash',              't',    'Flash',     'ffxiv/pld/flash' },
-  { 'battle 5 2',  'ma', 'Crusade',            'me',   'Crusade' },
-  { 'battle 5 3',  'ma', 'Foil',               'me',   'Foil' },
-  { 'battle 5 4',  'ma', 'Aquaveil',           'me',   'Aqua' },
+  { 'battle 5 1',  'ma', 'Flash',              'stnpc', 'Flash',     'ffxiv/pld/flash' },
+  { 'battle 5 2',  'ma', 'Crusade',            'me',    'Crusade' },
+  { 'battle 5 3',  'ma', 'Foil',               'me',    'Foil' },
+  { 'battle 5 4',  'ma', 'Aquaveil',           'me',    'Aqua' },
   -- Spikes
-  { 'battle 5 7',  'ma', 'Blaze Spikes',       'me',   'BlzSpikes' },
-  { 'battle 5 8',  'ma', 'Ice Spikes',         'me',   'IceSpikes' },
-  { 'battle 5 9',  'ma', 'Shock Spikes',       'me',   'ShkSpikes' },
+  { 'battle 5 7',  'ma', 'Blaze Spikes',       'me',    'BlzSpikes' },
+  { 'battle 5 8',  'ma', 'Ice Spikes',         'me',    'IceSpikes' },
+  { 'battle 5 9',  'ma', 'Shock Spikes',       'me',    'ShkSpikes' },
 
   -- Hotbar #6
   -- Bar-element Spells
-  { 'battle 6 1',  'ma', 'Barstone',           'me',   'BStone',    'Barstonra' },
-  { 'battle 6 2',  'ma', 'Barwater',           'me',   'BWater',    'Barwatera' },
-  { 'battle 6 3',  'ma', 'Baraero',            'me',   'BAero',     'Baraera' },
-  { 'battle 6 4',  'ma', 'Barfire',            'me',   'BFire',     'Barfira' },
-  { 'battle 6 5',  'ma', 'Barblizzard',        'me',   'BBlizzard', 'Barblizzara' },
-  { 'battle 6 6',  'ma', 'Barthunder',         'me',   'BThunder',  'Barthundra' },
+  { 'battle 6 1',  'ma', 'Barstone',           'me',    'BStone',    'Barstonra' },
+  { 'battle 6 2',  'ma', 'Barwater',           'me',    'BWater',    'Barwatera' },
+  { 'battle 6 3',  'ma', 'Baraero',            'me',    'BAero',     'Baraera' },
+  { 'battle 6 4',  'ma', 'Barfire',            'me',    'BFire',     'Barfira' },
+  { 'battle 6 5',  'ma', 'Barblizzard',        'me',    'BBlizzard', 'Barblizzara' },
+  { 'battle 6 6',  'ma', 'Barthunder',         'me',    'BThunder',  'Barthundra' },
   -- Bar-enfeeble Spells
-  { 'battle 6 7',  'ma', 'Barsleep',           'me',   'BSleep',    '' },
+  { 'battle 6 7',  'ma', 'Barsleep',           'me',    'BSleep',    '' },
   -- { 'battle 6 6',  'ma', 'Barpoison',          'me',    'BPoison',   '' },
-  { 'battle 6 8',  'ma', 'Barparalyze',        'me',   'BPara',     '' },
-  { 'battle 6 9',  'ma', 'Barblind',           'me',   'BBlind',    '' },
-  { 'battle 6 10', 'ma', 'Barsilence',         'me',   'BSilence',  '' },
+  { 'battle 6 8',  'ma', 'Barparalyze',        'me',    'BPara',     '' },
+  { 'battle 6 9',  'ma', 'Barblind',           'me',    'BBlind',    '' },
+  { 'battle 6 10', 'ma', 'Barsilence',         'me',    'BSilence',  '' },
   -- { 'battle 6 10', 'ma', 'Barvirus',           'me',    'BVirus',    '' },
-  { 'battle 6 11', 'ma', 'Barpetrify',         'me',   'BPetri',    '' },
-  { 'battle 6 12', 'ma', 'Baramnesia',         'me',   'Bamnesia',  '' },
+  { 'battle 6 11', 'ma', 'Barpetrify',         'me',    'BPetri',    '' },
+  { 'battle 6 12', 'ma', 'Baramnesia',         'me',    'Bamnesia',  '' },
 }
 
 -- SUBJOBS
@@ -91,8 +91,8 @@ xivhotbar_keybinds_job['DRK'] = {
   { 'battle 3 3', 'ja', 'Consume Mana',  'me',    'Consume', 'ffxiv/drk/syphon_strike' },
   { 'battle 3 4', 'ja', 'Weapon Bash',   't',     'Bash',    'ffxiv/drk/shadow_wall' },
   { 'battle 3 5', 'ja', 'Arcane Circle', 'me',    'Arcane',  'ffxiv/drk/salted_earth' },
-  { 'battle 3 6', 'ma', 'Bio',           't',     'Bio' },
-  { 'battle 3 6', 'ma', 'Bio II',        't',     'Bio2' },
+  { 'battle 3 6', 'ma', 'Bio',           'stnpc', 'Bio' },
+  { 'battle 3 6', 'ma', 'Bio II',        'stnpc', 'Bio2' },
   { 'battle 3 7', 'ma', 'Sleep',         'stnpc', 'Sleep' },
   { 'battle 3 7', 'ma', 'Sleep II',      'stnpc', 'Sleep2' },
   { 'battle 3 8', 'ma', 'Stun',          't',     'Stun' },
@@ -151,7 +151,7 @@ xivhotbar_keybinds_job['DNC'] = {
   { 'battle 3 9',  'ja', 'Stutter Step',      't',     'Stutter',  'ffxiv/dnc/fountainfall' },
   -- Flourishes
   { 'battle 3 10', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
-  { 'battle 3 11', 'ja', 'Violent Flourish',  't',     'Stun',     'ffxiv/dnc/starfall_dance' },
+  { 'battle 3 11', 'ja', 'Violent Flourish',  'stnpc', 'Stun',     'ffxiv/dnc/starfall_dance' },
   { 'battle 3 12', 'ja', 'Reverse Flourish',  'me',    'Reverse',  'ffxiv/dnc/reverse_cascade' },
   { 'battle 3 12', 'ja', 'Building Flourish', 'me',    'Building', 'ffxiv/dnc/flourish' },
   -- Jigs
@@ -160,12 +160,12 @@ xivhotbar_keybinds_job['DNC'] = {
 }
 
 xivhotbar_keybinds_job['MNK'] = {
-  { 'battle 3 1', 'ja', 'Boost',         'me', 'Boost',  'ffxiv/mnk/riddle_of_fire' },
-  { 'battle 3 2', 'ja', 'Dodge',         'me', 'Dodge',  'ffxiv/mnk/riddle_of_earth' },
-  { 'battle 3 3', 'ja', 'Focus',         'me', 'Focus',  'ffxiv/mnk/riddle_of_wind' },
-  { 'battle 3 4', 'ja', 'Chakra',        'me', 'Chakra', 'ffxiv/mnk/meditation' },
-  { 'battle 3 5', 'ja', 'Chi Blast',     't',  'Chi',    'ffxiv/mnk/elixir_field' },
-  { 'battle 3 6', 'ja', 'Counterstance', 'me', 'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
+  { 'battle 3 1', 'ja', 'Boost',         'me',    'Boost',  'ffxiv/mnk/riddle_of_fire' },
+  { 'battle 3 2', 'ja', 'Dodge',         'me',    'Dodge',  'ffxiv/mnk/riddle_of_earth' },
+  { 'battle 3 3', 'ja', 'Focus',         'me',    'Focus',  'ffxiv/mnk/riddle_of_wind' },
+  { 'battle 3 4', 'ja', 'Chakra',        'me',    'Chakra', 'ffxiv/mnk/meditation' },
+  { 'battle 3 5', 'ja', 'Chi Blast',     'stnpc', 'Chi',    'ffxiv/mnk/elixir_field' },
+  { 'battle 3 6', 'ja', 'Counterstance', 'me',    'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
 }
 
 xivhotbar_keybinds_job['THF'] = {
@@ -187,16 +187,16 @@ xivhotbar_keybinds_job['WAR'] = {
 
 xivhotbar_keybinds_job['WHM'] = {
   -- Abilities
-  { 'battle 3 12', 'ja', 'Divine Seal', 'me',   'Divine',  'ffxiv/whm/divine_benison' },
+  { 'battle 3 12', 'ja', 'Divine Seal', 'me',    'Divine',  'ffxiv/whm/divine_benison' },
   -- Enfeeblement
   -- { 'battle 3 ',  'ma', 'Paralyze',     'stnpc', 'Para' },
   -- { 'battle 3 ',  'ma', 'Slow',         'stnpc', 'Slow' },
   -- { 'battle 3 ',  'ma', 'Silence',      'stnpc', 'Silence' },
-  { 'battle 3 1',  'ma', 'Dia',         't',    'Dia' },
+  { 'battle 3 1',  'ma', 'Dia',         'stnpc', 'Dia' },
   --{ 'battle 3 2',  'ma', 'Dia II',      'stnpc', 'Dia II' },
   -- { 'battle 3 ',  'ma', 'Repose',       'stnpc', 'Repose' },
   -- { 'battle 3 ',  'ma', 'Flash',        'stnpc', 'Flash',     'ffxiv/pld/flash' },
-  { 'battle 3 3',  'ma', 'Aquaveil',    'me',   'Aquaveil' },
+  -- { 'battle 3 3',  'ma', 'Aquaveil',    'me',    'Aquaveil' },
   -- Barspells
   -- { 'battle 3 ',  'ma', 'Barsleepra',   'me',    'Sleepra',   '' },
   -- { 'battle 3 ',  'ma', 'Barpoisonra',  'me',    'Poisonra',  '' },
@@ -214,54 +214,60 @@ xivhotbar_keybinds_job['WHM'] = {
   -- Atk
   -- { 'battle 3 ',  'ma', 'Holy',         'stnpc', 'Holy' }, -- mastery
   -- Regen
-  { 'battle 3 5',  'ma', 'Regen',       'stpc', 'Regen' },
-  { 'battle 3 5',  'ma', 'Regen II',    'stpc', 'Regen2' },
+  -- { 'battle 3 5',  'ma', 'Regen',       'stpc',  'Regen' },
+  -- { 'battle 3 5',  'ma', 'Regen II',    'stpc',  'Regen2' },
   -- Cure
-  { 'battle 3 4',  'ma', 'Cure',        'stpc', 'Cure' },
-  { 'battle 3 4',  'ma', 'Cure II',     'stpc', 'Cure2' },
-  { 'battle 3 4',  'ma', 'Cure III',    'stpc', 'Cure3' },
-  { 'battle 3 4',  'ma', 'Cure IV',     'stpc', 'Cure4' },
+  { 'battle 3 2',  'ma', 'Cure',        'stpc',  'Cure' },
+  { 'battle 3 2',  'ma', 'Cure II',     'stpc',  'Cure2' },
+  { 'battle 3 2',  'ma', 'Cure III',    'stpc',  'Cure3' },
+  { 'battle 3 2',  'ma', 'Cure IV',     'stpc',  'Cure4' },
   -- Cura
   --{ 'battle 1 ',   'ma', 'Cura',        'me',    'Cura' },
   -- Curaga
-  { 'battle 3 6',  'ma', 'Curaga',      'stpc', 'Curaga' },
-  { 'battle 3 6',  'ma', 'Curaga II',   'stpc', 'Curaga2' },
-  { 'battle 3 6',  'ma', 'Curaga III',  'stpc', 'Curaga3' }, -- mastery
+  { 'battle 3 11', 'ma', 'Curaga',      'stpc',  'Curaga' },
+  { 'battle 3 11', 'ma', 'Curaga II',   'stpc',  'Curaga2' },
+  { 'battle 3 11', 'ma', 'Curaga III',  'stpc',  'Curaga3' }, -- mastery
   -- Supportive
-  { 'battle 3 7',  'ma', 'Poisona',     'stpc', 'Poisona' },
-  { 'battle 3 7',  'ma', 'Paralyna',    'stpc', 'Paralyna' },
-  { 'battle 3 7',  'ma', 'Blindna',     'stpc', 'Blindna' },
-  { 'battle 3 7',  'ma', 'Silena',      'stpc', 'Silena' },
-  { 'battle 3 7',  'ma', 'Blink',       'me',   'Blink' },
-  { 'battle 3 7',  'ma', 'Stoneskin',   'me',   'StnSkin' },
-  { 'battle 3 7',  'ma', 'Cursna',      'stpc', 'Cursna' },
-  { 'battle 3 7',  'ma', 'Erase',       'stpc', 'Erase' },
-  -- { 'battle 3 ',  'ma', 'Viruna',       'stpc',  'Viruna' },
-  -- { 'battle 3 ',  'ma', 'Stona',        'stpc',  'Stona' },
-  { 'battle 3 10', 'ma', 'Haste',       'stpc', 'Haste' },
-  { 'battle 3 11', 'ma', 'Auspice',     'me',   'Ausp' }, -- mastery
+  { 'battle 3 3',  'ma', 'Poisona',     'stpc',  'Poisona' },
+  { 'battle 3 4',  'ma', 'Paralyna',    'stpc',  'Paralyna' },
+  { 'battle 3 5',  'ma', 'Blindna',     'stpc',  'Blindna' },
+  { 'battle 3 6',  'ma', 'Silena',      'stpc',  'Silena' },
+  -- { 'battle 3 7',  'ma', 'Blink',       'me',    'Blink' },
+  -- { 'battle 3 8',  'ma', 'Stoneskin',   'me',    'StnSkin' },
+  { 'battle 3 7',  'ma', 'Cursna',      'stpc',  'Cursna' },
+  { 'battle 3 8',  'ma', 'Viruna',      'stpc',  'Viruna' },
+  { 'battle 3 9',  'ma', 'Stona',       'stpc',  'Stona' },
+  { 'battle 3 10', 'ma', 'Erase',       'stpc',  'Erase' },
+  -- { 'battle 3 10', 'ma', 'Haste',       'stpc',  'Haste' },
+  -- { 'battle 3 11', 'ma', 'Auspice',     'me',    'Ausp' }, -- mastery
 }
 
 xivhotbar_keybinds_job['RDM'] = {
-  { 'battle 3 1',  'ma', 'Cure',     'stpc',  'Cure 1' },
-  { 'battle 3 1',  'ma', 'Cure II',  'stpc',  'Cure 2' },
-  { 'battle 3 1',  'ma', 'Cure III', 'stpc',  'Cure 3' },
-  { 'battle 3 1',  'ma', 'Cure IV',  'stpc',  'Cure 4' },
+  { 'battle 3 1',  'ma', 'Dia',      'stnpc', 'Dia' },
 
-  { 'battle 3 1',  'ma', 'Refresh',  'stpc',  'Refresh' },
-  { 'battle 3 2',  'ma', 'Haste',    'stpc',  'Haste' },
-  { 'battle 3 3',  'ma', 'Dia',      't',     'Dia' },
-  --{ 'battle 3 3',  'ma', 'Dia II',   'stnpc', 'Dia2' },
+  { 'battle 3 2',  'ma', 'Cure',     'stpc',  'Cure 1' },
+  { 'battle 3 2',  'ma', 'Cure III', 'stpc',  'Cure 3' },
 
-  { 'battle 3 4',  'ma', 'Paralyze', 't',     'Paralyze' },
-  { 'battle 3 5',  'ma', 'Slow',     't',     'Slow' },
-  { 'battle 3 6',  'ma', 'Silence',  'stnpc', 'Silence' },
-  { 'battle 3 7',  'ma', 'Poison',   't',     'Paralyze' },
-  { 'battle 3 8',  'ma', 'Blind',    't',     'Slow' },
-  { 'battle 3 9',  'ma', 'Bind',     'stnpc', 'Bind' },
-  { 'battle 3 10', 'ma', 'Frazzle',  't',     'Frazzle' },
+  { 'battle 3 3',  'ma', 'Cure II',  'stpc',  'Cure 2' },
+  { 'battle 3 3',  'ma', 'Cure IV',  'stpc',  'Cure 4' },
 
-  { 'battle 3 11', 'ma', 'Phalanx',  'me',    'Phalanx' },
+  { 'battle 3 4',  'ma', 'Refresh',  'stpc',  'Refresh' },
+  { 'battle 3 5',  'ma', 'Haste',    'stpc',  'Haste' },
+  { 'battle 3 6',  'ma', 'Flurry',   'stpc',  'Flurry' },
+  { 'battle 3 7',  'ma', 'Phalanx',  'me',    'Phalanx' },
+
+  { 'battle 3 10', 'ma', 'Dia II',   'stnpc', 'Dia2' },
+  -- { 'battle 3 5',  'ma', 'Paralyze', 't',     'Paralyze' },
+  -- { 'battle 3 6',  'ma', 'Slow',     't',     'Slow' },
+  -- { 'battle 3 7',  'ma', 'Silence',  'stnpc', 'Silence' },
+  -- { 'battle 3 8',  'ma', 'Poison',   't',     'Paralyze' },
+  -- { 'battle 3 9',  'ma', 'Blind',    't',     'Slow' },
+  -- { 'battle 3 10', 'ma', 'Bind',     'stnpc', 'Bind' },
+  -- { 'battle 3 11', 'ma', 'Frazzle',  't',     'Frazzle' },
+  -- { 'battle 3 10', 'ma', 'Blink',     'me',    'Blink' },
+  -- { 'battle 3 11', 'ma', 'Stoneskin', 'me',    'StnSkin' },
+
+  { 'battle 3 12', 'ja', 'Convert',  'me',    'Convert' },
 }
 
 -- WEAPONSKILL SETS

--- a/data/Examples/sam.lua
+++ b/data/Examples/sam.lua
@@ -58,12 +58,12 @@ xivhotbar_keybinds_job['RNG'] = {
 }
 
 xivhotbar_keybinds_job['MNK'] = {
-  { 'battle 3 1', 'ja', 'Boost',         'me', 'Boost',  'ffxiv/mnk/riddle_of_fire' },
-  { 'battle 3 2', 'ja', 'Dodge',         'me', 'Dodge',  'ffxiv/mnk/riddle_of_earth' },
-  { 'battle 3 3', 'ja', 'Focus',         'me', 'Focus',  'ffxiv/mnk/riddle_of_wind' },
-  { 'battle 3 4', 'ja', 'Chakra',        'me', 'Chakra', 'ffxiv/mnk/meditation' },
-  { 'battle 3 5', 'ja', 'Chi Blast',     't',  'Chi',    'ffxiv/mnk/elixir_field' },
-  { 'battle 3 6', 'ja', 'Counterstance', 'me', 'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
+  { 'battle 3 1', 'ja', 'Boost',         'me',    'Boost',  'ffxiv/mnk/riddle_of_fire' },
+  { 'battle 3 2', 'ja', 'Dodge',         'me',    'Dodge',  'ffxiv/mnk/riddle_of_earth' },
+  { 'battle 3 3', 'ja', 'Focus',         'me',    'Focus',  'ffxiv/mnk/riddle_of_wind' },
+  { 'battle 3 4', 'ja', 'Chakra',        'me',    'Chakra', 'ffxiv/mnk/meditation' },
+  { 'battle 3 5', 'ja', 'Chi Blast',     'stnpc', 'Chi',    'ffxiv/mnk/elixir_field' },
+  { 'battle 3 6', 'ja', 'Counterstance', 'me',    'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
 }
 
 xivhotbar_keybinds_job['WAR'] = {
@@ -110,8 +110,8 @@ xivhotbar_keybinds_job['COR'] = {
 
 xivhotbar_keybinds_job['NIN'] = {
   -- Shadows
-  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me', 'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
-  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me', 'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
+  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me',    'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
+  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me',    'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
   -- Elements
   -- {'battle 3 7', 'ma', 'Katon: Ni', 'stnpc', 'Katon2','ffxiv/nin/katon'}, -- fire
   -- {'battle 3 7', 'ma', 'Katon: Ichi', 'stnpc', 'Katon','ffxiv/nin/katon'}, -- fire
@@ -126,14 +126,14 @@ xivhotbar_keybinds_job['NIN'] = {
   -- {'battle 3 12', 'ma', 'Raiton: Ni', 'stnpc', 'Raiton2','ffxiv/nin/raiton'}, -- thunder
   -- {'battle 3 12', 'ma', 'Raiton: Ichi', 'stnpc', 'Raiton','ffxiv/nin/raiton'}, -- thunder
   -- Enfeeblement
-  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 't',  'Kura',      'ffxiv/blu/glower' },      -- blind
-  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 't',  'Doku',      'ffxiv/blu/exuviation' },  -- poison
-  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   't',  'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
+  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 'stnpc', 'Kura',      'ffxiv/blu/glower' },      -- blind
+  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 'stnpc', 'Doku',      'ffxiv/blu/exuviation' },  -- poison
+  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   'stnpc', 'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
   -- Stances
-  { 'battle 3 11', 'ja', 'Yonin',          'me', 'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
-  { 'battle 3 12', 'ja', 'Innin',          'me', 'Innin',     'ffxiv/nin/assassinate' }, -- dps
+  { 'battle 3 11', 'ja', 'Yonin',          'me',    'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
+  { 'battle 3 12', 'ja', 'Innin',          'me',    'Innin',     'ffxiv/nin/assassinate' }, -- dps
 }
 
 xivhotbar_keybinds_job['DNC'] = {
@@ -155,7 +155,7 @@ xivhotbar_keybinds_job['DNC'] = {
   -- {'battle 3 9', 'ja', 'Stutter Step', 'stnpc', 'Stutter','ffxiv/dnc/fountainfall'},
   -- Flourishes
   { 'battle 3 12', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
-  { 'battle 3 9',  'ja', 'Violent Flourish',  't',     'Stun',     'ffxiv/dnc/starfall_dance' },
+  { 'battle 3 9',  'ja', 'Violent Flourish',  'stnpc', 'Stun',     'ffxiv/dnc/starfall_dance' },
   { 'battle 3 10', 'ja', 'Reverse Flourish',  'me',    'Reverse',  'ffxiv/dnc/reverse_cascade' },
   { 'battle 3 11', 'ja', 'Building Flourish', 'me',    'Building', 'ffxiv/dnc/flourish' },
   -- Jigs
@@ -176,8 +176,8 @@ xivhotbar_keybinds_job['DRK'] = {
   { 'battle 3 3', 'ja', 'Consume Mana',  'me',    'Consume', 'ffxiv/drk/syphon_strike' },
   { 'battle 3 4', 'ja', 'Weapon Bash',   't',     'Bash',    'ffxiv/drk/shadow_wall' },
   { 'battle 3 5', 'ja', 'Arcane Circle', 'me',    'Arcane',  'ffxiv/drk/salted_earth' },
-  { 'battle 3 6', 'ma', 'Bio',           't',     'Bio' },
-  { 'battle 3 6', 'ma', 'Bio II',        't',     'Bio2' },
+  { 'battle 3 6', 'ma', 'Bio',           'stnpc', 'Bio' },
+  { 'battle 3 6', 'ma', 'Bio II',        'stnpc', 'Bio2' },
   { 'battle 3 7', 'ma', 'Sleep',         'stnpc', 'Sleep' },
   { 'battle 3 7', 'ma', 'Sleep II',      'stnpc', 'Sleep2' },
   { 'battle 3 8', 'ma', 'Stun',          't',     'Stun' },

--- a/data/Examples/sch.lua
+++ b/data/Examples/sch.lua
@@ -1,18 +1,49 @@
--- Add
--- Kaustra
--- Embrava
-
 -- Load and initialize the include file.
 xivhotbar_keybinds_job['Base'] = {
 
   -- Hotbar #1
-  -- Reserved for Arts
+  --{'battle 1 1', '', '', '', ''},
+  --{'battle 1 2', '', '', '', ''},
+  --{'battle 1 3', '', '', '', ''},
+  --{'battle 1 4', '', '', '', ''},
+  --{'battle 1 5', '', '', '', ''},
+  --{'battle 1 6', '', '', '', ''},
+  --{'battle 1 7', '', '', '', ''},
+  --{'battle 1 8', '', '', '', ''},
+  --{'battle 1 9', '', '', '', ''},
+  --{'battle 1 10', '', '', '', ''},
+  --{'battle 1 11', '', '', '', ''},
+  --{'battle 1 12', '', '', '', ''},
+
 
   -- Hotbar #2
-  -- Reserved for Arts
+  --{'battle 2 1', 'a', '', '', ''},
+  --{'battle 2 2', '', '', '', ''},
+  --{'battle 2 3', '', '', '', ''},
+  --{'battle 2 4', '', '', '', ''},
+  --{'battle 2 5', '', '', '', ''},
+  --{'battle 2 6', '', '', '', ''},
+  --{'battle 2 7', '', '', '', ''},
+  --{'battle 2 8', '', '', '', ''},
+  --{'battle 2 9', '', '', '', ''},
+  --{'battle 2 10', '', '', '', ''},
+  --{'battle 2 11', '', '', '', ''},
+  --{'battle 2 12', '', '', '', ''},
+
 
   -- Hotbar #3
-  -- Subjob
+  --{'battle 3 1', '', '', '', ''},
+  --{'battle 3 2', '', '', '', ''},
+  --{'battle 3 3', '', '', '', ''},
+  --{'battle 3 4', '', '', '', ''},
+  --{'battle 3 5', '', '', '', ''},
+  --{'battle 3 6', '', '', '', ''},
+  --{'battle 3 7', '', '', '', ''},
+  --{'battle 3 8', '', '', '', ''},
+  --{'battle 3 9', '', '', '', ''},
+  --{'battle 3 10', '', '', '', ''},
+  --{'battle 3 11', '', '', '', ''},
+  { 'battle 3 12', 'ja', 'Tabula Rasa',      'me',    'TabulaR',  '2hr' },
 
   -- Hotbar #4
   { 'battle 4 1',  'ma', 'Blink',            'me',    'Blink' },
@@ -24,41 +55,42 @@ xivhotbar_keybinds_job['Base'] = {
   --{'battle 4 7', '', '', '', ''}, -- reserved for sub
   --------------------------------------------------------------------------------------
   { 'battle 4 8',  'ma', 'Raise',            'stpc',  'Raise' },
-  { 'battle 4 8',  'ma', 'Raise II',         'stpc',  'Raise2' },
-  { 'battle 4 8',  'ma', 'Raise III',        'stpc',  'Raise3' },
   --------------------------------------------------------------------------------------
-  -- { 'battle 4 10', 'ma', 'Protect',          'stpc', 'Prot' },
-  -- { 'battle 4 10', 'ma', 'Protect II',       'stpc', 'Prot2' },
-  -- { 'battle 4 10', 'ma', 'Protect III',      'stpc', 'Prot3' },
-  -- { 'battle 4 10', 'ma', 'Protect IV',       'stpc', 'Prot4' },
-  -- { 'battle 4 10', 'ma', 'Protect V',        'stpc', 'Prot5' },
+  { 'battle 4 10', 'ma', 'Protect',          'stpc',  'Prot' },
+  { 'battle 4 10', 'ma', 'Protect II',       'stpc',  'Prot2' },
+  { 'battle 4 10', 'ma', 'Protect III',      'stpc',  'Prot3' },
+  { 'battle 4 10', 'ma', 'Protect IV',       'stpc',  'Prot4' },
+  { 'battle 4 10', 'ma', 'Protect V',        'stpc',  'Prot5' },
   --------------------------------------------------------------------------------------
-  -- { 'battle 4 11', 'ma', 'Shell',            'stpc', 'Shell' },
-  -- { 'battle 4 11', 'ma', 'Shell II',         'stpc', 'Shell2' },
-  -- { 'battle 4 11', 'ma', 'Shell III',        'stpc', 'Shell3' },
-  -- { 'battle 4 11', 'ma', 'Shell IV',         'stpc', 'Shell4' },
-  -- { 'battle 4 11', 'ma', 'Shell V',          'stpc', 'Shell5' },
+  { 'battle 4 11', 'ma', 'Shell',            'stpc',  'Shell' },
+  { 'battle 4 11', 'ma', 'Shell II',         'stpc',  'Shell2' },
+  { 'battle 4 11', 'ma', 'Shell III',        'stpc',  'Shell3' },
+  { 'battle 4 11', 'ma', 'Shell IV',         'stpc',  'Shell4' },
+  { 'battle 4 11', 'ma', 'Shell V',          'stpc',  'Shell5' },
 
   { 'battle 4 11', 'ja', 'Caper Emissarius', 'stpc',  'Caper' },
-  { 'battle 4 12', 'ja', 'Tabula Rasa',      'me',    'TabulaR',  '2hr' },
 
   -- Hotbar #5
-  { 'battle 5 1',  'ma', 'Sandstorm',        'stpc',  'Sand' },
-  { 'battle 5 1',  'ma', 'Sandstorm II',     'stpc',  'Sand2' },
-  { 'battle 5 2',  'ma', 'Rainstorm',        'stpc',  'Rain' },
-  { 'battle 5 2',  'ma', 'Rainstorm II',     'stpc',  'Rain2' },
-  { 'battle 5 3',  'ma', 'Windstorm',        'stpc',  'Wind' },
-  { 'battle 5 3',  'ma', 'Windstorm II',     'stpc',  'Wind2' },
-  { 'battle 5 4',  'ma', 'Firestorm',        'stpc',  'Fire' },
-  { 'battle 5 4',  'ma', 'Firestorm II',     'stpc',  'Fire2' },
-  { 'battle 5 5',  'ma', 'Hailstorm',        'stpc',  'Hail' },
-  { 'battle 5 5',  'ma', 'Hailstorm II',     'stpc',  'Hail2' },
-  { 'battle 5 6',  'ma', 'Thunderstorm',     'stpc',  'Thdr' },
-  { 'battle 5 6',  'ma', 'Thunderstorm II',  'stpc',  'Thdr2' },
-  { 'battle 5 7',  'ma', 'Voidstorm',        'stpc',  'Void' },
-  { 'battle 5 7',  'ma', 'Voidstorm II',     'stpc',  'Void2' },
-  { 'battle 5 8',  'ma', 'Aurorastorm',      'stpc',  'Aurora' },
-  { 'battle 5 8',  'ma', 'Aurorastorm II',   'stpc',  'Aurora2' },
+  { 'battle 5 1',  'me', 'Sandstorm',        'stpc',  'Sand' },
+  { 'battle 5 1',  'me', 'Sandstorm II',     'stpc',  'Sand2' },
+  { 'battle 5 2',  'me', 'Rainstorm',        'stpc',  'Rain' },
+  { 'battle 5 2',  'me', 'Rainstorm II',     'stpc',  'Rain2' },
+  { 'battle 5 3',  'me', 'Windstorm',        'stpc',  'Wind' },
+  { 'battle 5 3',  'me', 'Windstorm II',     'stpc',  'Wind2' },
+  { 'battle 5 4',  'me', 'Firestorm',        'stpc',  'Fire' },
+  { 'battle 5 4',  'me', 'Firestorm II',     'stpc',  'Fire2' },
+  { 'battle 5 5',  'me', 'Hailstorm',        'stpc',  'Hail' },
+  { 'battle 5 5',  'me', 'Hailstorm II',     'stpc',  'Hail2' },
+  { 'battle 5 6',  'me', 'Thunderstorm',     'stpc',  'Thdr' },
+  { 'battle 5 6',  'me', 'Thunderstorm II',  'stpc',  'Thdr2' },
+  { 'battle 5 7',  'me', 'Voidstorm',        'stpc',  'Void' },
+  { 'battle 5 7',  'me', 'Voidstorm II',     'stpc',  'Void2' },
+  { 'battle 5 8',  'me', 'Aurorastorm',      'stpc',  'Aurora' },
+  { 'battle 5 8',  'me', 'Aurorastorm II',   'stpc',  'Aurora2' },
+  --{'battle 5 9', '', '', '', ''},
+  --{'battle 5 10', '', '', '', ''},
+  --{'battle 5 11', '', '', '', ''},
+  --{'battle 5 12', '', '', '', ''},
 
   -- Hotbar #6
   { 'battle 6 1',  'ja', 'Dark Arts',        'me',    'Dark' },
@@ -80,92 +112,99 @@ xivhotbar_keybinds_job['Base'] = {
   { 'battle 6 11', 'ja', 'Equanimity',       'me',    'Equan' },
   { 'battle 6 12', 'ja', 'Perpetuance',      'me',    'Perp' },
   { 'battle 6 12', 'ja', 'Immanence',        'me',    'Imma' },
+  --{'battle 6 9', '', '', '', ''},
+  --{'battle 6 10', '', '', '', ''},
+  --{'battle 6 11', '', '', '', ''},
+  --{'battle 6 12', '', '', '', ''},
 }
+
+
 
 xivhotbar_keybinds_job['Light Arts'] = {
   -- Hotbar #1 (1-12)
-  { 'battle 1 1',  'ma', 'Cure',         'stpc', 'Cure1' },
-  { 'battle 1 2',  'ma', 'Cure II',      'stpc', 'Cure2' },
-  { 'battle 1 3',  'ma', 'Cure III',     'stpc', 'Cure3' },
-  { 'battle 1 4',  'ma', 'Cure IV',      'stpc', 'Cure4' },
-  { 'battle 1 7',  'ma', 'Haste',        'stpc', 'Haste' },
+  { 'battle 1 1',  'ma',           'Cure',        'stpc', 'Cure1' },
+  { 'battle 1 2',  'ma',           'Cure II',     'stpc', 'Cure2' },
+  { 'battle 1 3',  'ma',           'Cure III',    'stpc', 'Cure3' },
+  { 'battle 1 4',  'ma',           'Cure IV',     'stpc', 'Cure4' },
+  { 'battle 1 7',  'ma',           'Haste',       'stpc', 'Haste' },
   --------------------------------------------------------------------------------------
-  { 'battle 1 8',  'ma', 'Regen',        'stpc', 'Regen' },
-  { 'battle 1 8',  'ma', 'Regen II',     'stpc', 'Regen2' },
-  { 'battle 1 8',  'ma', 'Regen III',    'stpc', 'Regen3' },
-  { 'battle 1 8',  'ma', 'Regen IV',     'stpc', 'Regen4' },
-  { 'battle 1 8',  'ma', 'Regen V',      'stpc', 'Regen5' },
+  { 'battle 1 8',  'ma',           'Regen',       'stpc', 'Regen' },
+  { 'battle 1 8',  'ma',           'Regen II',    'stpc', 'Regen2' },
+  { 'battle 1 8',  'ma',           'Regen III',   'stpc', 'Regen3' },
+  { 'battle 1 8',  'ma',           'Regen IV',    'stpc', 'Regen4' },
+  { 'battle 1 8',  'ma',           'Regen V',     'stpc', 'Regen5' },
   --------------------------------------------------------------------------------------
-  { 'battle 1 9',  'ma', 'Animus Augeo', 'stpc', '',        'Augeo' },
-  { 'battle 1 10', 'ma', 'Animus Minuo', 'stpc', '',        'Minuo' },
-  { 'battle 1 11', 'ma', 'Adloquium',    'stpc', '',        'Adloq' },
-  -- {'battle 2 9', '', '', '', ''},  -- reserved for sub
+  { 'battle 1 9',  'Animus Augeo', 'stpc',        '',     'Augeo' },
+  { 'battle 1 10', 'Animus Minuo', 'stpc',        '',     'Minuo' },
+  { 'battle 1 11', 'Adloquium',    'stpc',        '',     'Adloq' },
+  --{'battle 1 12', '', '', '', ''}, -- reserved for sub
 
   -- Hotbar #2 (ALT 1-12)
-  { 'battle 2 1',  'ma', 'Poisona',      'stpc', 'Poisona' },
-  { 'battle 2 2',  'ma', 'Paralyna',     'stpc', 'Paralyna' },
-  { 'battle 2 3',  'ma', 'Blindna',      'stpc', 'Blindna' },
-  { 'battle 2 4',  'ma', 'Silena',       'stpc', 'Silena' },
-  { 'battle 2 5',  'ma', 'Cursna',       'stpc', 'Cursna' },
-  { 'battle 2 6',  'ma', 'Viruna',       'stpc', 'Viruna' },
-  { 'battle 2 7',  'ma', 'Stona',        'stpc', 'Stona' },
-  { 'battle 2 8',  'ma', 'Erase',        'stpc', 'Erase' },
+  { 'battle 2 1',  'ma',           'Poisona',     'stpc', 'Poisona' },
+  { 'battle 2 2',  'ma',           'Paralyna',    'stpc', 'Paralyna' },
+  { 'battle 2 3',  'ma',           'Blindna',     'stpc', 'Blindna' },
+  { 'battle 2 4',  'ma',           'Silena',      'stpc', 'Silena' },
+  { 'battle 2 5',  'ma',           'Cursna',      'stpc', 'Cursna' },
+  { 'battle 2 6',  'ma',           'Viruna',      'stpc', 'Viruna' },
+  { 'battle 2 7',  'ma',           'Stona',       'stpc', 'Stona' },
+  { 'battle 2 8',  'ma',           'Erase',       'stpc', 'Erase' },
   --------------------------------------------------------------------------------------
   -- {'battle 2 9', '', '', '', ''},  -- reserved for sub
   --------------------------------------------------------------------------------------
-  { 'battle 2 10', 'ma', 'Reraise',      'me',   'Reraise' },
-  { 'battle 2 10', 'ma', 'Reraise II',   'me',   'Reraise2' },
-  { 'battle 2 10', 'ma', 'Reraise III',  'me',   'Reraise3' },
+  { 'battle 2 10', 'ma',           'Reraise',     'me',   'Reraise' },
+  { 'battle 2 10', 'ma',           'Reraise II',  'me',   'Reraise2' },
+  { 'battle 2 10', 'ma',           'Reraise III', 'me',   'Reraise3' },
   --{'battle 2 11', '', '', '', ''}, -- reserved for sub
   --{'battle 2 12', '', '', '', ''}, -- reserved for sub
 
 
   -- Hotbar #3 (CTRL 1-12)
   -- Mostly reserved for sub job
-  { 'battle 3 12', 'ma', 'Embrava',      'stpc', 'Embrava' },
 
   -- Hotbar #4 (SHIFT 1-12)
   --{'battle 4 7', '', '', '', ''}, -- reserved for sub
   --------------------------------------------------------------------------------------
-  { 'battle 4 8',  'ma', 'Raise',        'stpc', 'Raise' },
-  { 'battle 4 8',  'ma', 'Raise II',     'stpc', 'Raise2' },
-  { 'battle 4 8',  'ma', 'Raise III',    'stpc', 'Raise3' },
+  { 'battle 4 8',  'ma',           'Raise',       'stpc', 'Raise' },
+  { 'battle 4 8',  'ma',           'Raise II',    'stpc', 'Raise2' },
+  { 'battle 4 8',  'ma',           'Raise III',   'stpc', 'Raise3' },
+  --------------------------------------------------------------------------------------
+  --{'battle 4 9', '', '', '', ''},
+  --{'battle 4 10', '', '', '', ''},
   --------------------------------------------------------------------------------------
 }
 
 xivhotbar_keybinds_job['Dark Arts'] = {
   -- Hotbar #1 (1-12)
-  -- Black Elemental
-  { 'battle 1 1',  'ma', 'Stone',        't',     'Stone' },
-  { 'battle 1 1',  'ma', 'Stone II',     't',     'Stone2' },
-  { 'battle 1 1',  'ma', 'Stone IV',     't',     'Stone4' },
-  { 'battle 1 1',  'ma', 'Stone V',      't',     'Stone5' },
-  { 'battle 1 2',  'ma', 'Water',        't',     'Water' },
-  { 'battle 1 2',  'ma', 'Water II',     't',     'Water2' },
-  { 'battle 1 2',  'ma', 'Water III',    't',     'Water3' },
-  { 'battle 1 2',  'ma', 'Water IV',     't',     'Water4' },
-  { 'battle 1 2',  'ma', 'Water V',      't',     'Water5' },
-  { 'battle 1 3',  'ma', 'Aero',         't',     'Aero' },
-  { 'battle 1 3',  'ma', 'Aero II',      't',     'Aero2' },
-  { 'battle 1 3',  'ma', 'Aero III',     't',     'Aero3' },
-  { 'battle 1 3',  'ma', 'Aero IV',      't',     'Aero4' },
-  { 'battle 1 3',  'ma', 'Aero V',       't',     'Aero5' },
-  { 'battle 1 4',  'ma', 'Fire',         't',     'Fire' },
-  { 'battle 1 4',  'ma', 'Fire II',      't',     'Fire2' },
-  { 'battle 1 4',  'ma', 'Fire III',     't',     'Fire3' },
-  { 'battle 1 4',  'ma', 'Fire IV',      't',     'Fire4' },
-  { 'battle 1 4',  'ma', 'Fire V',       't',     'Fire5' },
-  { 'battle 1 5',  'ma', 'Blizzard',     't',     'Blizz' },
-  { 'battle 1 5',  'ma', 'Blizzard II',  't',     'Blizz2' },
-  { 'battle 1 5',  'ma', 'Blizzard III', 't',     'Blizz3' },
-  { 'battle 1 5',  'ma', 'Blizzard IV',  't',     'Blizz4' },
-  { 'battle 1 5',  'ma', 'Blizzard V',   't',     'Blizz5' },
-  { 'battle 1 6',  'ma', 'Thunder',      't',     'Thund' },
-  { 'battle 1 6',  'ma', 'Thunder II',   't',     'Thund2' },
-  { 'battle 1 6',  'ma', 'Thunder III',  't',     'Thund3' },
-  { 'battle 1 6',  'ma', 'Thunder IV',   't',     'Thund4' },
-  { 'battle 1 6',  'ma', 'Thunder V',    't',     'Thund5' },
-  -- Black Enfeeblement
+  { 'battle 1 1',  'ma', 'Stone',        'stnpc', 'Stone' },
+  { 'battle 1 1',  'ma', 'Stone II',     'stnpc', 'Stone2' },
+  { 'battle 1 1',  'ma', 'Stone III',    'stnpc', 'Stone3' },
+  { 'battle 1 1',  'ma', 'Stone IV',     'stnpc', 'Stone4' },
+  { 'battle 1 1',  'ma', 'Stone V',      'stnpc', 'Stone5' },
+  { 'battle 1 2',  'ma', 'Water',        'stnpc', 'Water' },
+  { 'battle 1 2',  'ma', 'Water II',     'stnpc', 'Water2' },
+  { 'battle 1 2',  'ma', 'Water III',    'stnpc', 'Water3' },
+  { 'battle 1 2',  'ma', 'Water IV',     'stnpc', 'Water4' },
+  { 'battle 1 2',  'ma', 'Water V',      'stnpc', 'Water5' },
+  { 'battle 1 3',  'ma', 'Aero',         'stnpc', 'Aero' },
+  { 'battle 1 3',  'ma', 'Aero II',      'stnpc', 'Aero2' },
+  { 'battle 1 3',  'ma', 'Aero III',     'stnpc', 'Aero3' },
+  { 'battle 1 3',  'ma', 'Aero IV',      'stnpc', 'Aero4' },
+  { 'battle 1 3',  'ma', 'Aero V',       'stnpc', 'Aero5' },
+  { 'battle 1 4',  'ma', 'Fire',         'stnpc', 'Fire' },
+  { 'battle 1 4',  'ma', 'Fire II',      'stnpc', 'Fire2' },
+  { 'battle 1 4',  'ma', 'Fire III',     'stnpc', 'Fire3' },
+  { 'battle 1 4',  'ma', 'Fire IV',      'stnpc', 'Fire4' },
+  { 'battle 1 4',  'ma', 'Fire V',       'stnpc', 'Fire5' },
+  { 'battle 1 5',  'ma', 'Blizzard',     'stnpc', 'Blizz' },
+  { 'battle 1 5',  'ma', 'Blizzard II',  'stnpc', 'Blizz2' },
+  { 'battle 1 5',  'ma', 'Blizzard III', 'stnpc', 'Blizz3' },
+  { 'battle 1 5',  'ma', 'Blizzard IV',  'stnpc', 'Blizz4' },
+  { 'battle 1 5',  'ma', 'Blizzard V',   'stnpc', 'Blizz5' },
+  { 'battle 1 6',  'ma', 'Thunder',      'stnpc', 'Thund' },
+  { 'battle 1 6',  'ma', 'Thunder II',   'stnpc', 'Thund2' },
+  { 'battle 1 6',  'ma', 'Thunder III',  'stnpc', 'Thund3' },
+  { 'battle 1 6',  'ma', 'Thunder IV',   'stnpc', 'Thund4' },
+  { 'battle 1 6',  'ma', 'Thunder V',    'stnpc', 'Thund5' },
   { 'battle 1 7',  'ma', 'Sleep',        'stnpc', 'Sleep' },
   { 'battle 1 8',  'ma', 'Sleep II',     'stnpc', 'Sleep2' },
   { 'battle 1 9',  'ma', 'Break',        'stnpc', 'Break' },
@@ -174,19 +213,17 @@ xivhotbar_keybinds_job['Dark Arts'] = {
   --{'battle 1 12', '', '', '', ''}, -- reserved for sub
 
   -- Hotbar #2 (ALT 1-12)
-  -- Helix
-  { 'battle 2 1',  'ma', 'Geohelix',     't',     'Geo' },
-  { 'battle 2 2',  'ma', 'Hydrohelix',   't',     'Hydro' },
-  { 'battle 2 3',  'ma', 'Anemohelix',   't',     'Anemo' },
-  { 'battle 2 4',  'ma', 'Pyrohelix',    't',     'Pyro' },
-  { 'battle 2 5',  'ma', 'Cryohelix',    't',     'Cryo' },
-  { 'battle 2 6',  'ma', 'Ionohelix',    't',     'Iono' },
-  { 'battle 2 7',  'ma', 'Noctohelix',   't',     'Nocto' },
-  { 'battle 2 8',  'ma', 'Luminohelix',  't',     'Lumino' },
+  { 'battle 2 1',  'ma', 'Geohelix',     'stnpc', 'Geo' },
+  { 'battle 2 2',  'ma', 'Hydrohelix',   'stnpc', 'Hydro' },
+  { 'battle 2 3',  'ma', 'Anemohelix',   'stnpc', 'Anemo' },
+  { 'battle 2 4',  'ma', 'Pyrohelix',    'stnpc', 'Pyro' },
+  { 'battle 2 5',  'ma', 'Cryohelix',    'stnpc', 'Cryo' },
+  { 'battle 2 6',  'ma', 'Ionohelix',    'stnpc', 'Iono' },
+  { 'battle 2 7',  'ma', 'Noctohelix',   'stnpc', 'Nocto' },
+  { 'battle 2 8',  'ma', 'Luminohelix',  'stnpc', 'Lumino' },
   --------------------------------------------------------------------------------------
   -- {'battle 2 9', '', '', '', ''},  -- reserved for sub
   --------------------------------------------------------------------------------------
-  --- Spikes
   { 'battle 2 10', 'ma', 'Blaze Spikes', 'me',    'B. Spikes' },
   { 'battle 2 10', 'ma', 'Ice Spikes',   'me',    'I. Spikes' },
   { 'battle 2 10', 'ma', 'Shock Spikes', 'me',    'S. Spikes' },
@@ -196,266 +233,100 @@ xivhotbar_keybinds_job['Dark Arts'] = {
 
   -- Hotbar #3 (CTRL 1-12)
   -- Mostly reserved for sub job
-  { 'battle 3 12', 'ma', 'Kaustra',      'stnpc', 'Kaustra' },
 
   -- Hotbar #4 (SHIFT 1-12)
 
   --{'battle 4 7', '', '', '', ''}, -- reserved for sub
   --------------------------------------------------------------------------------------
-  { 'battle 4 9',  'ma', 'Drain',        't',     'Drain' },
-  { 'battle 4 10', 'ma', 'Aspir',        't',     'Aspir' },
-  { 'battle 4 10', 'ma', 'Aspir II',     't',     'Aspir2' },
+  { 'battle 4 9',  'ma', 'Drain',        'stnpc', 'Drain' },
+  { 'battle 4 10', 'ma', 'Aspir',        'stnpc', 'Aspir' },
+  { 'battle 4 10', 'ma', 'Aspir II',     'stnpc', 'Aspir2' },
 }
 
--- SUBJOBS
--- Uses...
----- Hotbar 1 12
----- Hotbar 2 9 -- job ability
----- Hotbar 2 11
----- Hotbar 2 12
----- Hotbar 3 1-11
----- Hotbar 4 7
 xivhotbar_keybinds_job['WHM'] = {
-  -- Abilities
-  { 'battle 2 9',  'ja', 'Divine Seal',  'me',    'Divine',    'ffxiv/whm/divine_benison' },
-  -- Enfeeblement
-  { 'battle 3 2',  'ma', 'Paralyze',     't',     'Para' },
-  { 'battle 3 3',  'ma', 'Slow',         't',     'Slow' },
-  { 'battle 3 4',  'ma', 'Silence',      'stnpc', 'Silence' },
-  { 'battle 3 1',  'ma', 'Dia',          't',     'Dia' },
-  { 'battle 3 1',  'ma', 'Dia II',       't',     'Dia II' },
-  { 'battle 4 7',  'ma', 'Repose',       'stnpc', 'Repose' },
-  -- { 'battle 3 9',  'ma', 'Flash',        'stnpc', 'Flash',     'ffxiv/pld/flash' },
-  -- { 'battle 3 1',  'ma', 'Aquaveil',     'me',    'Aquaveil' },
-  -- Barspells
-  { 'battle 3 7',  'ma', 'Barsleepra',   'me',    'Sleepra',   '' },
-  -- { 'battle 3 7',  'ma', 'Barpoisonra',  'me',    'Poisonra',  '' },
-  { 'battle 3 8',  'ma', 'Barparalyzra', 'me',    'Paralyzra', '' },
-  -- { 'battle 3 7',  'ma', 'Barstonra',    'me',    'Stonra',    'Barstonra' },
-  -- { 'battle 3 8',  'ma', 'Barwatera',    'me',    'Watera',    'Barwatera' },
-  -- { 'battle 3 8',  'ma', 'Baraera',      'me',    'Aera',      'Baraera' },
-  -- { 'battle 3 4',  'ma', 'Barfira',      'me',    'Fira',      'Barfira' },
-  -- { 'battle 3 4',  'ma', 'Barblindra',   'me',    'Blindra',   '' },
-  -- { 'battle 3 5',  'ma', 'Barblizzara',  'me',    'Blizzara',  'Barblizzara' },
-  -- { 'battle 3 5',  'ma', 'Barsilencera', 'me',    'Silencera' },
-  { 'battle 3 10', 'ma', 'Barthundra',   'me',    'Thundra',   'Barthundra' },
-  -- { 'battle 3 6',  'ma', 'Barvira',      'me',    'Vira' },
-  { 'battle 3 9',  'ma', 'Barpetra',     'me',    'Petra' },
-  -- Atk
-  { 'battle 3 5',  'ma', 'Banish',       't',     'Banish' },
-  { 'battle 3 5',  'ma', 'Banish II',    't',     'Banish2' },
-  { 'battle 3 6',  'ma', 'Holy',         't',     'Holy' }, -- mastery
-  -- Regen
-  -- { 'battle 3 11', 'ma', 'Regen',        'stpc',  'Regen' },
-  -- { 'battle 3 11', 'ma', 'Regen II',     'stpc',  'Regen2' },
-  -- Cure
-  -- { 'battle 3 10', 'ma', 'Cure',         'stpc',  'Cure' },
-  -- { 'battle 3 10', 'ma', 'Cure II',      'stpc',  'Cure2' },
-  -- { 'battle 3 10', 'ma', 'Cure III',     'stpc',  'Cure3' },
-  -- { 'battle 3 10', 'ma', 'Cure IV',      'stpc',  'Cure4' },
-  -- Cura
-  { 'battle 1 12', 'ma', 'Cura',         'me',    'Cura' },
-  -- Curaga
-  -- { 'battle 3 12', 'ma', 'Curaga',       'stpc',  'Curaga' },
-  -- { 'battle 3 12', 'ma', 'Curaga II',    'stpc',  'Curaga2' },
-  -- { 'battle 3 12', 'ma', 'Curaga III',   'stpc',  'Curaga3' }, -- mastery
-  -- Supportive
-  -- { 'battle 3 1',  'ma', 'Poisona',      'stpc',  'Poisona' },
-  -- { 'battle 3 2',  'ma', 'Paralyna',     'stpc',  'Paralyna' },
-  -- { 'battle 3 3',  'ma', 'Blindna',      'stpc',  'Blindna' },
-  -- { 'battle 3 4',  'ma', 'Silena',       'stpc',  'Silena' },
-  -- { 'battle 3 6',  'ma', 'Blink',        'me',    'Blink' },
-  -- { 'battle 3 7',  'ma', 'Stoneskin',    'me',    'StnSkin' },
-  -- { 'battle 3 5',  'ma', 'Cursna',       'stpc',  'Cursna' },
-  -- { 'battle 3 7',  'ma', 'Erase',        'stpc',  'Erase' },
-  -- { 'battle 3 6',  'ma', 'Viruna',       'stpc',  'Viruna' },
-  -- { 'battle 3 4',  'ma', 'Stona',        'stpc',  'Stona' },
-  { 'battle 2 12', 'ma', 'Haste',        'stpc',  'Haste' },
-  { 'battle 3 11', 'ma', 'Auspice',      'me',    'Ausp' }, -- mastery
+  -- BAR 1
+  { 'battle 1 12', 'ma', 'Cura',        'me',    'Cura' },
+
+  -- BAR 2
+  { 'battle 2 9',  'ja', 'Divine Seal', 'me',    'Div.Seal' },
+  { 'battle 2 12', 'ma', 'Haste',       'stpc',  'Haste' },
+
+  -- BAR 3
+  { 'battle 3 1',  'ma', 'Dia',         'stnpc', 'Dia' },
+  { 'battle 3 1',  'ma', 'Dia II',      'stnpc', 'Dia2' },
+
+  { 'battle 3 2',  'ma', 'Paralyze',    't',     'Paralyze' },
+  { 'battle 3 3',  'ma', 'Slow',        't',     'Slow' },
+  { 'battle 3 4',  'ma', 'Silence',     'stnpc', 'Silence' },
+  { 'battle 3 5',  'ma', 'Banish I',    't',     'Banish' },
+  { 'battle 3 5',  'ma', 'Banish II',   't',     'Banish2' },
+  { 'battle 3 6',  'ma', 'Holy',        't',     'Holy' },
+
+  { 'battle 3 10', 'ma', 'Dia',         't',     'Dia' },
+  { 'battle 3 11', 'ma', 'Diaga',       'stnpc', 'Diaga' },
+
+  -- BAR 4
+  { 'battle 4 7',  'ma', 'Repose',      'stnpc', 'Repose' },
 }
 
 xivhotbar_keybinds_job['BLM'] = {
-  -- Abilities
-  { 'battle 2 9',  'ja', 'Elemental Seal', 'me',    'E Seal',  'ffxiv/blm/foul' },
-  -- Elemental
-  -- { 'battle 3 2',  'ma', 'Stone',          'stnpc', 'Stone' },
-  -- { 'battle 3 2',  'ma', 'Stone II',       'stnpc', 'Stone2' },
-  -- { 'battle 3 2',  'ma', 'Stone III',      'stnpc', 'Stone3' }, -- mastery
-  -- { 'battle 3 2',  'ma', 'Water',          'stnpc', 'Water' },
-  -- { 'battle 3 2',  'ma', 'Water II',       'stnpc', 'Water2' },
-  -- { 'battle 3 2',  'ma', 'Water III',      'stnpc', 'Water3' }, -- mastery
-  -- { 'battle 3 2',  'ma', 'Aero',           'stnpc', 'Aero' },
-  -- { 'battle 3 2',  'ma', 'Aero II',        'stnpc', 'Aero2' },
-  -- { 'battle 3 2',  'ma', 'Aero III',       'stnpc', 'Aero3' }, -- mastery
-  -- { 'battle 3 2',  'ma', 'Fire',           'stnpc', 'Fire' },
-  -- { 'battle 3 2',  'ma', 'Fire II',        'stnpc', 'Fire2' },
-  -- { 'battle 3 2',  'ma', 'Blizzard',       'stnpc', 'Blizzard' },
-  -- { 'battle 3 2',  'ma', 'Blizzard II',    'stnpc', 'Blizzard2' },
-  -- { 'battle 3 2',  'ma', 'Thunder',        'stnpc', 'Thunder' },
-  -- { 'battle 3 2',  'ma', 'Thunder II',     'stnpc', 'Thunder2' },
-  -- { 'battle 3 2',  'ma', 'Drain',          'stpc',  'Drain' },
-  -- { 'battle 3 2',  'ma', 'Aspir',          'stpc',  'Aspir' },
-  -- Elemental AoE
-  -- { 'battle 3 2',  'ma', 'Stonega',        'stnpc', 'Stga' },
-  -- { 'battle 3 2',  'ma', 'Stonega II',     'stnpc', 'Stga2' },
-  -- { 'battle 3 2',  'ma', 'Waterga',        'stnpc', 'Waga' },
-  -- { 'battle 3 2',  'ma', 'Waterga II',     'stnpc', 'Waga2' },
-  -- { 'battle 3 2',  'ma', 'Aeroga',         'stnpc', 'Aega' },
-  -- { 'battle 3 2',  'ma', 'Aeroga II',      'stnpc', 'Aega2' },
-  -- { 'battle 3 2',  'ma', 'Firaga',         'stnpc', 'Figa' },
-  -- { 'battle 3 2',  'ma', 'Firaga II',      'stnpc', 'Figa2' }, -- mastery
-  -- { 'battle 3 2',  'ma', 'Blizzaga',       'stnpc', 'Blga' },
-  -- { 'battle 3 2',  'ma', 'Blizzaga II',    'stnpc', 'Blga2' }, -- mastery
-  -- { 'battle 3 2',  'ma', 'Thundaga',       'stnpc', 'Thga' },
-  -- Ancient Magic
-  -- { 'battle 3 2',  'ma', 'Freeze',         'stnpc', 'Freeze' },  -- mastery
-  -- { 'battle 3 2',  'ma', 'Tornado',        'stnpc', 'Tornado' }, -- mastery
-  -- { 'battle 3 2',  'ma', 'Quake',          'stnpc', 'Quake' },   -- mastery
-  -- { 'battle 3 2',  'ma', 'Burst',          'stnpc', 'Burst' },   -- mastery
-  -- { 'battle 3 2',  'ma', 'Flood',          'stnpc', 'Flood' },   -- mastery
-  -- Elemental DoTs
-  -- { 'battle 3 10', 'ma', 'Shock',          'stpc',  'Shock' },
-  -- { 'battle 3 5',  'ma', 'Rasp',           'stpc',  'Rasp' },
-  -- { 'battle 3 7',  'ma', 'Frost',          'stpc',  'Frost' },
-  -- { 'battle 3 6',  'ma', 'Choke',          'stpc',  'Choke' },
-  -- { 'battle 3 8',  'ma', 'Burn',           'stpc',  'Burn' },
-  -- { 'battle 3 9',  'ma', 'Drown',          'stpc',  'Drown' },
-  -- Enfeeblement
-  { 'battle 3 2',  'ma', 'Poison',         't',     'Poison' },
-  { 'battle 3 2',  'ma', 'Poison II',      't',     'Poison2' },
-  -- { 'battle 3 2',  'ma', 'Poisonga',       'stpc',  'Psnga' },
-  { 'battle 3 3',  'ma', 'Blind',          't',     'Blind' },
-  { 'battle 3 4',  'ma', 'Bind',           'stnpc', 'Bind' },
+  -- BAR 1
+  { 'battle 1 12', 'ma', 'Stun',           't',     'Stun' },
+
+  -- BAR 2
+  { 'battle 2 9',  'ja', 'Elemental Seal', 'me',    'E.Seal' },
+
+  -- BAR 3
   { 'battle 3 1',  'ma', 'Bio',            't',     'Bio' },
   { 'battle 3 1',  'ma', 'Bio II',         't',     'Bio2' },
-  -- { 'battle 3 2',  'ma', 'Sleep',          'stnpc', 'Sleep' },
-  -- { 'battle 3 2',  'ma', 'Sleep II',       'stnpc', 'Sleep2' }, -- mastery
-  { 'battle 1 12', 'ma', 'Stun',           't',     'Stun' },
-  { 'battle 3 5',  'ma', 'Sleepga',        'stnpc', 'Sleepga' },
-  { 'battle 3 6',  'ma', 'Sleepga II',     'stnpc', 'Sleepga2' }, -- mastery
-  -- Spikes
-  -- { 'battle 3 2',  'ma', 'Blaze Spikes',   'me',    'BlzSpk' },
-  -- { 'battle 3 2',  'ma', 'Ice Spikes',     'me',    'IceSpk' },
-  -- { 'battle 3 2',  'ma', 'Shock Spikes',   'me',    'ShkSpk' },
-  -- Utility
-  -- { 'battle 3 11', 'ma', 'Tractor',        'stpc',  'Tractor' },
-  -- { 'battle 3 2',  'ma', 'Escape',         'me',    'Escape' },
-  -- { 'battle 3 2',  'ma', 'Warp',           'me',    'Warp' },
-  -- { 'battle 3 2',  'ma', 'Warp II',        'stnc',  'Warp2' },
-  -- { 'battle 3 2',  'ma', 'Retrace',        'stnc',  'Retrace' }, -- mastery
+
+  { 'battle 3 2',  'ma', 'Poison',         't',     'Poison' },
+  { 'battle 3 3',  'ma', 'Blind',          't',     'Blind' },
+  { 'battle 3 4',  'ma', 'Bind',           'stnpc', 'Bind' },
+  { 'battle 3 5',  'ma', 'Rasp',           't',     'Rasp' },
+  { 'battle 3 6',  'ma', 'Choke',          't',     'Choke' },
+  { 'battle 3 7',  'ma', 'Frost',          't',     'Frost' },
+  { 'battle 3 8',  'ma', 'Burn',           't',     'Burn' },
+  { 'battle 3 9',  'ma', 'Drown',          't',     'Drown' },
+  { 'battle 3 10', 'ma', 'Shock',          't',     'Shock' },
+  { 'battle 3 11', 'ma', 'Tractor',        't',     'Tractor' },
+
+  -- BAR 4
+  { 'battle 4 7',  'ma', 'Sleepga',        'stnpc', 'Sleepga' },
 }
 
 xivhotbar_keybinds_job['RDM'] = {
-  -- Abilities
-  { 'battle 2 9',  'ja', 'Convert',  'me',    'Convert', 'ffxiv/rdm/magic_barrier' },
-  -- Enspells
-  -- { 'battle 6 7',  'ma', 'Enstone',       'me',    'Enstone' },
-  -- { 'battle 6 7',  'ma', 'Enstone II',    'me',    'Enstone2' }, -- mastery
-  -- { 'battle 6 8',  'ma', 'Enwater',       'me',    'Enwater' },
-  -- { 'battle 6 8',  'ma', 'Enwater II',    'me',    'Enwater2' }, -- mastery
-  -- { 'battle 6 9',  'ma', 'Enaero',        'me',    'Enaero' },
-  -- { 'battle 6 9',  'ma', 'Enaero II',     'me',    'Enaero2' },  -- mastery
-  -- { 'battle 6 10', 'ma', 'Enfire',        'me',    'Enfire' },
-  -- { 'battle 6 10', 'ma', 'Enfire II',     'me',    'Enfire2' },  -- mastery
-  -- { 'battle 6 11', 'ma', 'Enblizzard',    'me',    'Enblizz' },
-  -- { 'battle 6 11', 'ma', 'Enblizzard II', 'me',    'Enblizz2' }, -- mastery
-  -- { 'battle 6 12', 'ma', 'Enthunder',     'me',    'Enthun' },
-  -- { 'battle 6 12', 'ma', 'Enthunder II',  'me',    'Enthun2' },  -- mastery
-  --Enfeeblement
-  { 'battle 3 1',  'ma', 'Dia',      't',     'Dia' },
-  { 'battle 3 1',  'ma', 'Dia II',   't',     'Dia2' },
-  -- { 'battle 3 4',  'ma', 'Diaga',         'stnpc', 'Diaga' },
-  -- { 'battle 3 3',  'ma', 'Poison',        'stnpc', 'Poison' },
-  -- { 'battle 3 3',  'ma', 'Poison II',     'stnpc', 'Poison2' },
-  { 'battle 3 3',  'ma', 'Paralyze', 't',     'Paralyze' },
-  { 'battle 3 4',  'ma', 'Blind',    't',     'Blind' },
-  { 'battle 3 2',  'ma', 'Bio',      't',     'Bio' },
-  { 'battle 3 2',  'ma', 'Bio II',   't',     'Bio2' },
-  { 'battle 3 5',  'ma', 'Bind',     'stnpc', 'Bind' },
-  { 'battle 3 6',  'ma', 'Slow',     't',     'Slow' },
-  { 'battle 3 7',  'ma', 'Silence',  'stnpc', 'Silence' },
-  { 'battle 3 8',  'ma', 'Gravity',  'stnpc', 'Gravity' },
-  -- { 'battle 3 7',  'ma', 'Sleep',         'stnpc', 'Sleep' },
-  -- { 'battle 3 7',  'ma', 'Sleep II',      'stnpc', 'Sleep2' },
-  -- { 'battle 3 ',  'ma', 'Dispel',        'stnpc', 'Dispel' },
-  { 'battle 3 10', 'ma', 'Distract', 't',     'Distract' },
-  { 'battle 3 9',  'ma', 'Frazzle',  't',     'Frazzle' },
-  -- White Magic
-  -- { 'battle 1 1',  'ma', 'Cure',          'stpc',  'Cure' },
-  -- { 'battle 1 1',  'ma', 'Cure II',       'stpc',  'Cure2' },
-  -- { 'battle 1 1',  'ma', 'Cure III',      'stpc',  'Cure3' },
-  -- { 'battle 1 1',  'ma', 'Cure IV',       'stpc',  'Cure 4' },
-  -- { 'battle 2 1',  'ma', 'Regen',         'stpc',  'Regen' },
-  -- Black Magic
-  -- { 'battle 5 1',  'ma', 'Stone',         'stnpc', 'Stone' },
-  -- { 'battle 5 1',  'ma', 'Stone II',      'stnpc', 'Stone2' },
-  -- { 'battle 5 1',  'ma', 'Water',         'stnpc', 'Water' },
-  -- { 'battle 5 1',  'ma', 'Water II',      'stnpc', 'Water2' },
-  -- { 'battle 5 1',  'ma', 'Aero',          'stnpc', 'Aero' },
-  -- { 'battle 5 1',  'ma', 'Aero II',       'stnpc', 'Aero2' }, -- mastery
-  -- { 'battle 5 1',  'ma', 'Fire',          'stnpc', 'Fire' },
-  -- { 'battle 5 1',  'ma', 'Fire II',       'stnpc', 'Fire2' }, -- mastery
-  -- { 'battle 5 1',  'ma', 'Blizzard',      'stnpc', 'Blizzard' },
-  -- { 'battle 5 1',  'ma', 'Thunder',       'stnpc', 'Thunder' },
-  -- Buffs
-  { 'battle 2 11', 'ma', 'Refresh',  'stpc',  'Refresh' },
-  { 'battle 2 12', 'ma', 'Haste',    'stpc',  'Haste' },
-  { 'battle 4 7',  'ma', 'Flurry',   'stpc',  'Flurry' },
-  -- { 'battle 1 1',  'ma', 'Aquaveil',      'me',    'Aquaveil' },
-  -- { 'battle 3 6',  'ma', 'Blink',         'me',    'Blink' },
-  { 'battle 3 11', 'ma', 'Phalanx',  'me',    'Phalanx' },
-  -- { 'battle 3 7',  'ma', 'Stoneskin',     'me',    'StnSkin' },
-  -- { 'battle 5 7',  'ma', 'Blaze Spikes',  'me',    'BlzSpikes' },
-  -- { 'battle 5 8',  'ma', 'Ice Spikes',    'me',    'IceSpikes' },
-  -- Barspells
-  -- { 'battle 5 7',  'ma', 'Barstone',      'me',    'BStone',    'Barstonra' },
-  -- { 'battle 5 8',  'ma', 'Barwater',      'me',    'BWater',    'Barwatera' },
-  -- { 'battle 5 9',  'ma', 'Baraero',       'me',    'BAero',     'Baraera' },
-  -- { 'battle 5 10', 'ma', 'Barfire',       'me',    'BFire',     'Barfira' },
-  -- { 'battle 5 11', 'ma', 'Barblizzard',   'me',    'BBlizzard', 'Barblizzara' },
-  -- { 'battle 5 12', 'ma', 'Barthunder',    'me',    'BThunder',  'Barthundra' },
-  -- { 'battle 6 5',  'ma', 'Barsleep',      'me',    'BSleep',    '' },
-  -- { 'battle 6 6',  'ma', 'Barpoison',     'me',    'BPoison',   '' },
-  -- { 'battle 6 7',  'ma', 'Barparalyze',   'me',    'BPara',     '' },
-  -- { 'battle 6 8',  'ma', 'Barblind',      'me',    'BBlind',    '' },
-  -- { 'battle 6 9',  'ma', 'Barsilence',    'me',    'BSilence',  '' },
-  -- { 'battle 6 10', 'ma', 'Barvirus',      'me',    'BVirus',    '' },
-  -- { 'battle 6 11', 'ma', 'Barpetrify',    'me',    'BPetri',    '' },
+  -- BAR 2
+  { 'battle 2 8',  'ma', 'Refresh',  'stpc',  'Refresh' },
+  { 'battle 2 11', 'ma', 'Haste',    'stpc',  'Haste' },
+  { 'battle 2 12', 'ma', 'Flurry',   'stpc',  'Flurry' },
+
+  -- BAR 3
+  { 'battle 3 1',  'ma', 'Dia',      'stnpc', 'Dia' },
+  { 'battle 3 1',  'ma', 'Dia II',   'stnpc', 'Dia2' },
+
+  { 'battle 3 2',  'ma', 'Paralyze', 't',     'Paralyze' },
+  { 'battle 3 3',  'ma', 'Slow',     't',     'Slow' },
+  { 'battle 3 4',  'ma', 'Silence',  'stnpc', 'Silence' },
+  { 'battle 3 5',  'ma', 'Poison',   't',     'Paralyze' },
+  { 'battle 3 6',  'ma', 'Blind',    't',     'Slow' },
+  { 'battle 3 7',  'ma', 'Bind',     'stnpc', 'Bind' },
+  { 'battle 3 8',  'ma', 'Frazzle',  't',     'Frazzle' },
+
+  { 'battle 3 10', 'ma', 'Bio',      't',     'Dia' },
+  { 'battle 3 11', 'ma', 'Diaga',    'stnpc', 'Diaga' },
+
+  -- BAR 4
+  { 'battle 4 7',  'ma', 'Phalanx',  'me',    'Phalanx' },
 }
 
-xivhotbar_keybinds_job['COR'] = {
-  { 'battle 3 1',  'ja', "Double-Up",      'me', 'Dbl Up', 'ffxiv/ast/play' },
-  { 'battle 3 2',  'ja', "Corsair's Roll", 'me', 'COR',    'classes/ast' }, -- exp
-  { 'battle 3 3',  'ja', "Ninja Roll",     'me', 'NIN',    'classes/nin' }, -- eva
-  { 'battle 3 4',  'ja', "Hunter's Roll",  'me', 'HUN',    'classes/acr' }, -- acc & ra acc
-  { 'battle 3 5',  'ja', "Chaos Roll",     'me', 'CHS',    'classes/rpr' }, -- phys atk
-  { 'battle 3 7',  'ja', "Magus's Roll",   'me', 'MGS',    'classes/whm' }, -- mag def
-  -- {'battle 3 7', 'ja', "Healer's Roll", 'me', 'HLR','classes/hlr'}, -- cure potency
-  -- {'battle 3 8', 'ja', "Drachen Roll", 'me', 'DRC','classes/lnc'}, -- pet & ra acc
-  -- {'battle 3 9', 'ja', "Choral Roll", 'me', 'CRL','classes/brd'}, -- spell interrupt
-  -- {'battle 3 10', 'ja', "Monk's Roll", 'me', 'MNK','classes/mnk'}, -- subtle blow
-  -- {'battle 3 11', 'ja', "Beast Roll", 'me', 'BST','classes/war'}, -- pet atk
-  { 'battle 3 3',  'ja', "Samurai Roll",   'me', 'SAM',    'classes/sam' }, -- store TP
-  -- {'battle 3 3', 'ja', "Quick Draw", 'me', 'QkDraw','classes/mch'},
-  { 'battle 3 9',  'ja', "Evoker's Roll",  'me', 'EVO',    'classes/smn' }, -- MP regen
-  { 'battle 3 6',  'ja', "Rogue's Roll",   'me', 'RGE',    'classes/rge' }, -- crit
-  -- {'battle 3 4', 'ja', "Warlock's Roll", 'me', 'WLK','classes/thm'}, -- magic acc
-  { 'battle 3 2',  'ja', "Fighter's Roll", 'me', 'FTR',    'classes/mar' }, -- double atk
-  -- Mastery only
-  -- {'battle 3 6', 'ja', "Puppet Roll", 'me', 'PUP','classes/pug'}, -- pet matk & pet macc
-  { 'battle 3 8',  'ja', "Gallant's Roll", 'me', 'GAL',    'classes/pld' }, -- def
-  -- {'battle 3 8', 'ja', "Wizard's Roll", 'me', 'WIZ','classes/blm'}, -- matk
-  { 'battle 3 12', 'ja', "Random Deal",    'me', 'Randm',  'ffxiv/ast/draw' },
-}
-
--- WEAPONSKILL SETS
 xivhotbar_keybinds_job['Club'] = {
-  { 'battle 5 12', 'ws', 'Shining Strike', 't',  'Shining' },
-  { 'battle 5 12', 'ws', 'Starlight',      'me', 'Star' },
-  { 'battle 5 12', 'ws', 'True Strike',    't',  'True' },
-  { 'battle 5 12', 'ws', 'Black Halo',     't',  'Halo' },
-  { 'battle 5 12', 'ws', 'Realmrazer',     't',  'Razer' },
-  { 'battle 5 12', 'ws', 'Randgrith',      't',  'RGrith' },
+  { 'battle 5 12', 'ws', 'Shining Strike', 't', 'Shining' },
+  { 'battle 5 12', 'ws', 'Starlight',      't', 'Star' },
+  { 'battle 5 12', 'ws', 'True Strike',    't', 'True' },
+  { 'battle 5 12', 'ws', 'Black Halo',     't', 'Halo' },
+  { 'battle 5 12', 'ws', 'Realmrazer',     't', 'Razer' },
+  { 'battle 5 12', 'ws', 'Randgrith',      't', 'RGrith' },
 }
 
 xivhotbar_keybinds_job['Staff'] = {

--- a/data/Examples/smn.lua
+++ b/data/Examples/smn.lua
@@ -274,8 +274,7 @@ xivhotbar_keybinds_job['Siren'] = {
 }
 
 -- SUBJOBS
--- 3 1-12 available
--- 4 1-10 available
+-- 4, 1-10 available
 xivhotbar_keybinds_job['THF'] = {
   { 'battle 3 3', 'ja', 'Steal',        't',  'Steal', 'ffxiv/nin/dream_within_a_dream' },
   { 'battle 3 1', 'ja', 'Sneak Attack', 'me', 'SAtk',  'ffxiv/nin/spinning_edge' },
@@ -324,96 +323,96 @@ xivhotbar_keybinds_job['COR'] = {
 
 xivhotbar_keybinds_job['RDM'] = {
   -- Abilities
-  { 'battle 4 10', 'ja', 'Convert', 'me',    'Convert', 'ffxiv/rdm/magic_barrier' },
+  { 'battle 3 12', 'ja', 'Convert',    'me',    'Convert',  'ffxiv/rdm/magic_barrier' },
   -- Enspells
-  -- { 'battle 3 7',  'ma', 'Enstone',       'me',    'Enstone' },
   -- { 'battle 3 7',  'ma', 'Enstone II',    'me',    'Enstone2' }, -- mastery
-  -- { 'battle 3 8',  'ma', 'Enwater',       'me',    'Enwater' },
+  -- { 'battle 3 7',  'ma', 'Enstone',       'me',    'Enstone' },
   -- { 'battle 3 8',  'ma', 'Enwater II',    'me',    'Enwater2' }, -- mastery
-  -- { 'battle 3 9',  'ma', 'Enaero',        'me',    'Enaero' },
+  -- { 'battle 3 8',  'ma', 'Enwater',       'me',    'Enwater' },
   -- { 'battle 3 9',  'ma', 'Enaero II',     'me',    'Enaero2' },  -- mastery
-  -- { 'battle 3 10', 'ma', 'Enfire',        'me',    'Enfire' },
+  -- { 'battle 3 9',  'ma', 'Enaero',        'me',    'Enaero' },
   -- { 'battle 3 10', 'ma', 'Enfire II',     'me',    'Enfire2' },  -- mastery
-  -- { 'battle 3 11', 'ma', 'Enblizzard',    'me',    'Enblizz' },
+  -- { 'battle 3 10', 'ma', 'Enfire',        'me',    'Enfire' },
   -- { 'battle 3 11', 'ma', 'Enblizzard II', 'me',    'Enblizz2' }, -- mastery
-  -- { 'battle 3 12', 'ma', 'Enthunder',     'me',    'Enthun' },
+  -- { 'battle 3 11', 'ma', 'Enblizzard',    'me',    'Enblizz' },
   -- { 'battle 3 12', 'ma', 'Enthunder II',  'me',    'Enthun2' },  -- mastery
+  -- { 'battle 3 12', 'ma', 'Enthunder',     'me',    'Enthun' },
   --Enfeeblement
-  { 'battle 4 1',  'ma', 'Dia',     't',     'Dia' },
-  { 'battle 4 1',  'ma', 'Dia II',  't',     'Dia2' },
-  { 'battle 4 10', 'ma', 'Diaga',   't',     'Diaga' },
-  -- { 'battle 3 ',  'ma', 'Poison',        't', 'Poison' },
-  -- { 'battle 3 ',  'ma', 'Poison II',     't', 'Poison2' },
-  -- { 'battle 3 ',  'ma', 'Paralyze',      't', 'Paralyze' },
-  -- { 'battle 3 ',  'ma', 'Blind',         't', 'Blind' },
-  { 'battle 4 2',  'ma', 'Bio',     't',     'Bio' },
-  { 'battle 4 2',  'ma', 'Bio II',  't',     'Bio2' },
-  { 'battle 4 3',  'ma', 'Bind',    'stnpc', 'Bind' },
-  -- { 'battle 3 ',  'ma', 'Slow',          't', 'Slow' },
-  { 'battle 4 4',  'ma', 'Silence', 'stnpc', 'Silence' },
-  { 'battle 4 5',  'ma', 'Gravity', 'stnpc', 'Gravity' }, S
-{ 'battle 4 6', 'ma', 'Sleep', 'stnpc', 'Sleep' },
-  { 'battle 4 7',  'ma', 'Sleep II',   'stnpc', 'Sleep2' },
+  { 'battle 4 7',  'ma', 'Dia',        'stnpc', 'Dia' },
+  { 'battle 4 7',  'ma', 'Dia II',     'stnpc', 'Dia2' },
+  -- { 'battle 3 ',  'ma', 'Diaga',         'stnpc', 'Diaga' },
+  -- { 'battle 3 ',  'ma', 'Poison II',     'stnpc', 'Poison2' },
+  -- { 'battle 3 ',  'ma', 'Poison',        'stnpc', 'Poison' },
+  -- { 'battle 3 ',  'ma', 'Paralyze',      'stnpc', 'Paralyze' },
+  -- { 'battle 3 ',  'ma', 'Blind',         'stnpc', 'Blind' },
+  -- { 'battle 3 ',  'ma', 'Bio II',        'stnpc', 'Bio2' },
+  -- { 'battle 3 ',  'ma', 'Bio',           'stnpc', 'Bio' },
+  -- { 'battle 3 ', 'ma', 'Bind',          'stnpc', 'Bind' },
+  -- { 'battle 3 ',  'ma', 'Slow',          'stnpc', 'Slow' },
+  -- { 'battle 3 ',   'ma', 'Silence',    'stnpc', 'Silence' },
+  -- { 'battle 3 ',   'ma', 'Gravity',    'stnpc', 'Gravity' },S
+  { 'battle 4 10', 'ma', 'Sleep II',   'stnpc', 'Sleep2' },
+  { 'battle 4 9',  'ma', 'Sleep',      'stnpc', 'Sleep' },
   { 'battle 4 8',  'ma', 'Dispel',     'stnpc', 'Dispel' },
-  -- { 'battle 3 ',  'ma', 'Distract',      't', 'Distract' },
-  { 'battle 4 9',  'ma', 'Frazzle',    't',     'Frazzle' },
+  -- { 'battle 3 ',  'ma', 'Distract',      'stnpc', 'Distract' },
+  -- { 'battle 3 ',  'ma', 'Frazzle',       'stnpc', 'Frazzle' },
   -- White Magic
-  { 'battle 3 1',  'ma', 'Cure',       'stpc',  'Cure' },
   { 'battle 3 1',  'ma', 'Cure II',    'stpc',  'Cure2' },
   { 'battle 3 1',  'ma', 'Cure III',   'stpc',  'Cure3' },
   { 'battle 3 1',  'ma', 'Cure IV',    'stpc',  'Cure 4' },
+  { 'battle 3 1',  'ma', 'Cure',       'stpc',  'Cure' },
   { 'battle 3 2',  'ma', 'Regen',      'stpc',  'Regen' },
   -- Black Magic
-  -- { 'battle 3 1',  'ma', 'Stone',         'stnpc', 'Stone' },
   -- { 'battle 3 1',  'ma', 'Stone II',      'stnpc', 'Stone2' },
-  -- { 'battle 3 1',  'ma', 'Water',         'stnpc', 'Water' },
+  -- { 'battle 3 1',  'ma', 'Stone',         'stnpc', 'Stone' },
   -- { 'battle 3 1',  'ma', 'Water II',      'stnpc', 'Water2' },
-  -- { 'battle 3 1',  'ma', 'Aero',          'stnpc', 'Aero' },
+  -- { 'battle 3 1',  'ma', 'Water',         'stnpc', 'Water' },
   -- { 'battle 3 1',  'ma', 'Aero II',       'stnpc', 'Aero2' }, -- mastery
-  -- { 'battle 3 1',  'ma', 'Fire',          'stnpc', 'Fire' },
+  -- { 'battle 3 1',  'ma', 'Aero',          'stnpc', 'Aero' },
   -- { 'battle 3 1',  'ma', 'Fire II',       'stnpc', 'Fire2' }, -- mastery
+  -- { 'battle 3 1',  'ma', 'Fire',          'stnpc', 'Fire' },
   -- { 'battle 3 1',  'ma', 'Blizzard',      'stnpc', 'Blizzard' },
   -- { 'battle 3 1',  'ma', 'Thunder',       'stnpc', 'Thunder' },
   -- Buffs
   { 'battle 3 3',  'ma', 'Refresh',    'stpc',  'Refresh' },
   { 'battle 3 4',  'ma', 'Haste',      'stpc',  'Haste' },
   { 'battle 3 5',  'ma', 'Flurry',     'stpc',  'Flurry' },
-  { 'battle 4 6',  'ma', 'Aquaveil',   'me',    'Aquaveil' },
-  { 'battle 4 7',  'ma', 'Blink',      'me',    'Blink' },
-  { 'battle 4 8',  'ma', 'Phalanx',    'me',    'Phalanx' },
-  { 'battle 4 9',  'ma', 'Stoneskin',  'me',    'StnSkin' },
+  { 'battle 4 1',  'ma', 'Aquaveil',   'me',    'Aquaveil' },
+  { 'battle 4 2',  'ma', 'Blink',      'me',    'Blink' },
+  { 'battle 4 4',  'ma', 'Phalanx',    'me',    'Phalanx' },
+  { 'battle 4 3',  'ma', 'Stoneskin',  'me',    'StnSkin' },
   -- { 'battle 3 7',  'ma', 'Blaze Spikes',  'me',    'BlzSpikes' },
-  { 'battle 3 10', 'ma', 'Ice Spikes', 'me',    'IceSpikes' },
+  -- { 'battle 3 8',  'ma', 'Ice Spikes',    'me',    'IceSpikes' },
   -- Barspells
   -- { 'battle 3 7',  'ma', 'Barstone',      'me',    'BStone',    'Barstonra' },
   -- { 'battle 3 8',  'ma', 'Barwater',      'me',    'BWater',    'Barwatera' },
   -- { 'battle 3 9',  'ma', 'Baraero',       'me',    'BAero',     'Baraera' },
   -- { 'battle 3 10', 'ma', 'Barfire',       'me',    'BFire',     'Barfira' },
   -- { 'battle 3 11', 'ma', 'Barblizzard',   'me',    'BBlizzard', 'Barblizzara' },
-  { 'battle 3 11', 'ma', 'Barthunder', 'me',    'BThunder', 'Barthundra' },
+  { 'battle 4 5',  'ma', 'Barthunder', 'me',    'BThunder', 'Barthundra' },
   -- { 'battle 3 5',  'ma', 'Barsleep',      'me',    'BSleep',    '' },
   -- { 'battle 3 6',  'ma', 'Barpoison',     'me',    'BPoison',   '' },
   -- { 'battle 3 7',  'ma', 'Barparalyze',   'me',    'BPara',     '' },
   -- { 'battle 3 8',  'ma', 'Barblind',      'me',    'BBlind',    '' },
-  { 'battle 3 12', 'ma', 'Barsilence', 'me',    'BSilence', '' },
+  { 'battle 4 6',  'ma', 'Barsilence', 'me',    'BSilence', '' },
   -- { 'battle 3 10', 'ma', 'Barvirus',      'me',    'BVirus',    '' },
   -- { 'battle 3 11', 'ma', 'Barpetrify',    'me',    'BPetri',    '' },
 }
 
 xivhotbar_keybinds_job['WHM'] = {
   -- Abilities
-  { 'battle 4 10', 'ja', 'Divine Seal', 'me',    'Divine',  'ffxiv/whm/divine_benison' },
+  { 'battle 3 12', 'ja', 'Divine Seal', 'me',    'Divine',   'ffxiv/whm/divine_benison' },
   -- Enfeeblement
-  -- { 'battle 3 2',  'ma', 'Paralyze',     't',     'Para' },
-  -- { 'battle 3 3',  'ma', 'Slow',         't',     'Slow' },
-  { 'battle 4 2',  'ma', 'Silence',     'stnpc', 'Silence' },
-  { 'battle 4 1',  'ma', 'Dia',         't',     'Dia' },
-  { 'battle 4 1',  'ma', 'Dia II',      't',     'Dia II' },
-  { 'battle 4 3',  'ma', 'Repose',      'stnpc', 'Repose' },
-  -- { 'battle 3 9',  'ma', 'Flash',        't',     'Flash',     'ffxiv/pld/flash' },
-  { 'battle 4 9',  'ma', 'Aquaveil',    'me',    'Aquaveil' },
+  -- { 'battle 3 ',  'ma', 'Paralyze',     'stnpc', 'Para' },
+  -- { 'battle 3 ',  'ma', 'Slow',         'stnpc', 'Slow' },
+  -- { 'battle 3 ',  'ma', 'Silence',      'stnpc', 'Silence' },
+  { 'battle 4 7',  'ma', 'Dia',         'stnpc', 'Dia' },
+  { 'battle 4 7',  'ma', 'Dia II',      'stnpc', 'Dia II' },
+  { 'battle 4 9',  'ma', 'Repose',      'stnpc', 'Repose' },
+  -- { 'battle 3 ',  'ma', 'Flash',        'stnpc', 'Flash',     'ffxiv/pld/flash' },
+  { 'battle 4 1',  'ma', 'Aquaveil',    'me',    'Aquaveil' },
   -- Barspells
-  -- { 'battle 3 ',  'ma', 'Barsleepra',   'me',    'Sleepra',   '' },
+  { 'battle 4 6',  'ma', 'Barsleepra',  'me',    'Sleepra',  '' },
   -- { 'battle 3 ',  'ma', 'Barpoisonra',  'me',    'Poisonra',  '' },
   -- { 'battle 3 ',  'ma', 'Barparalyzra', 'me',    'Paralyzra', '' },
   -- { 'battle 3 ',  'ma', 'Barstonra',    'me',    'Stonra',    'Barstonra' },
@@ -421,15 +420,13 @@ xivhotbar_keybinds_job['WHM'] = {
   -- { 'battle 3 ',  'ma', 'Baraera',      'me',    'Aera',      'Baraera' },
   -- { 'battle 3 ',  'ma', 'Barfira',      'me',    'Fira',      'Barfira' },
   -- { 'battle 3 ',  'ma', 'Barblindra',   'me',    'Blindra',   '' },
-  -- { 'battle 3 ',  'ma', 'Barblizzara',  'me',    'Blizzara',  'Barblizzara' },
-  -- { 'battle 4 8',  'ma', 'Barsilencera', 'me',    'Silencera' },
-  -- { 'battle 4 7',  'ma', 'Barthundra',   'me',    'Thundra',   'Barthundra' },
+  { 'battle 4 4',  'ma', 'Barblizzara', 'me',    'Blizzara', 'Barblizzara' },
+  -- { 'battle 3 ',  'ma', 'Barsilencera', 'me',    'Silencera' },
+  { 'battle 4 5',  'ma', 'Barthundra',  'me',    'Thundra',  'Barthundra' },
   -- { 'battle 3 ',  'ma', 'Barvira',      'me',    'Vira' },
   -- { 'battle 3 ',  'ma', 'Barpetra',     'me',    'Petra' },
   -- Atk
-  -- { 'battle 3 5',  'ma', 'Banish',       't',     'Banish' },
-  -- { 'battle 3 5',  'ma', 'Banish II',    't',     'Banish2' },
-  -- { 'battle 3 9',  'ma', 'Holy',         't',     'Holy' }, -- mastery
+  -- { 'battle 3 ',  'ma', 'Holy',         'stnpc', 'Holy' }, -- mastery
   -- Regen
   { 'battle 3 2',  'ma', 'Regen',       'stpc',  'Regen' },
   { 'battle 3 2',  'ma', 'Regen II',    'stpc',  'Regen2' },
@@ -439,54 +436,54 @@ xivhotbar_keybinds_job['WHM'] = {
   { 'battle 3 1',  'ma', 'Cure III',    'stpc',  'Cure3' },
   { 'battle 3 1',  'ma', 'Cure IV',     'stpc',  'Cure4' },
   -- Cura
-  { 'battle 1 3',  'ma', 'Cura',        'me',    'Cura' },
+  -- { 'battle 3 ', 'ma', 'Cura',         'me',    'Cura' },
   -- Curaga
-  { 'battle 3 4',  'ma', 'Curaga',      'stpc',  'Curaga' },
-  { 'battle 3 4',  'ma', 'Curaga II',   'stpc',  'Curaga2' },
-  { 'battle 3 4',  'ma', 'Curaga III',  'stpc',  'Curaga3' }, -- mastery
+  { 'battle 3 3',  'ma', 'Curaga',      'stpc',  'Curaga' },
+  { 'battle 3 3',  'ma', 'Curaga II',   'stpc',  'Curaga2' },
+  { 'battle 3 3',  'ma', 'Curaga III',  'stpc',  'Curaga3' }, -- mastery
   -- Supportive
-  { 'battle 3 5',  'ma', 'Poisona',     'stpc',  'Poisona' },
-  { 'battle 3 6',  'ma', 'Paralyna',    'stpc',  'Paralyna' },
-  { 'battle 3 7',  'ma', 'Blindna',     'stpc',  'Blindna' },
-  { 'battle 3 8',  'ma', 'Silena',      'stpc',  'Silena' },
-  { 'battle 4 7',  'ma', 'Blink',       'me',    'Blink' },
-  { 'battle 4 6',  'ma', 'Stoneskin',   'me',    'StnSkin' },
-  { 'battle 3 9',  'ma', 'Cursna',      'stpc',  'Cursna' },
-  { 'battle 3 10', 'ma', 'Erase',       'stpc',  'Erase' },
-  { 'battle 3 11', 'ma', 'Viruna',      'stpc',  'Viruna' },
-  { 'battle 3 12', 'ma', 'Stona',       'stpc',  'Stona' },
-  { 'battle 4 5',  'ma', 'Haste',       'stpc',  'Haste' },
-  { 'battle 4 8',  'ma', 'Auspice',     'me',    'Ausp' }, -- mastery
+  -- { 'battle 3 4',  'ma', 'Poisona',      'stpc',  'Poisona' },
+  -- { 'battle 3 4',  'ma', 'Paralyna',     'stpc',  'Paralyna' },
+  -- { 'battle 3 4',  'ma', 'Blindna',      'stpc',  'Blindna' },
+  -- { 'battle 3 4',  'ma', 'Silena',       'stpc',  'Silena' },
+  { 'battle 4 2',  'ma', 'Blink',       'me',    'Blink' },
+  { 'battle 4 3',  'ma', 'Stoneskin',   'me',    'StnSkin' },
+  -- { 'battle 3 4',  'ma', 'Cursna',       'stpc',  'Cursna' },
+  { 'battle 3 5',  'ma', 'Erase',       'stpc',  'Erase' },
+  -- { 'battle 3 4',  'ma', 'Viruna',       'stpc',  'Viruna' },
+  -- { 'battle 3 4',  'ma', 'Stona',        'stpc',  'Stona' },
+  { 'battle 3 4',  'ma', 'Haste',       'stpc',  'Haste' },
+  -- { 'battle 3 ',  'ma', 'Auspice',      'me',    'Ausp' }, -- mastery
 }
 
 xivhotbar_keybinds_job['SCH'] = {
   -- Abilities
-  { 'battle 4 10', 'ja', 'Dark Arts',       'me',   'Dark',     'ffxiv/sch/ruin' },
-  { 'battle 4 9',  'ja', 'Light Arts',      'me',   'Light',    'ffxiv/sch/ruin_II' },
-  { 'battle 3 7',  'ja', 'Sublimation',     'me',   'Sublim',   'ffxiv/sch/aetherflow' },
-  { 'battle 3 8',  'ja', 'Penury',          'me',   'Penury',   'ffxiv/sch/dissipation' },        -- shares A - reduce MP
-  { 'battle 3 8',  'ja', 'Parsimony',       'me',   'Parsmy',   'ffxiv/sch/broil_IV' },           -- shares A - reduce MP
-  { 'battle 3 9',  'ja', 'Celerity',        'me',   'Celrty',   'ffxiv/sch/expedient' },          -- shares B - reduce cast
-  { 'battle 3 9',  'ja', 'Alacrity',        'me',   'Alacty',   'ffxiv/sch/deployment_tactics' }, -- shares B - reduce cast
-  { 'battle 3 10', 'ja', 'Addendum: White', 'me',   'Add.Wht',  'ffxiv/sch/excogitation' },
-  { 'battle 3 10', 'ja', 'Addendum: Black', 'me',   'Add.Blk',  'ffxiv/sch/recitation' },
-  { 'battle 3 11', 'ja', 'Accession',       'me',   'Accssn',   'ffxiv/sch/protraction' },   -- shares C - extend
-  { 'battle 3 11', 'ja', 'Manifestation',   'me',   'Manifst',  'ffxiv/sch/biolysis' },      -- shares C - extend
-  { 'battle 3 12', 'ja', 'Rapture',         'me',   'Raptur',   'ffxiv/sch/art_of_war_II' }, -- shares D - mastery - potency
-  { 'battle 3 12', 'ja', 'Ebullience',      'me',   'Ebull',    'ffxiv/sch/art_of_war' },    -- Shares D - mastery - potency
+  { 'battle 4 11', 'ja', 'Dark Arts',       'me',   'Dark',     'ffxiv/sch/ruin' },
+  { 'battle 4 10', 'ja', 'Light Arts',      'me',   'Light',    'ffxiv/sch/ruin_II' },
+  { 'battle 3 12', 'ja', 'Sublimation',     'me',   'Sublim',   'ffxiv/sch/aetherflow' },
+  { 'battle 4 5',  'ja', 'Penury',          'me',   'Penury',   'ffxiv/sch/dissipation' },        -- shares A - reduce MP
+  { 'battle 4 5',  'ja', 'Parsimony',       'me',   'Parsmy',   'ffxiv/sch/broil_IV' },           -- shares A - reduce MP
+  { 'battle 4 6',  'ja', 'Celerity',        'me',   'Celrty',   'ffxiv/sch/expedient' },          -- shares B - reduce cast
+  { 'battle 4 6',  'ja', 'Alacrity',        'me',   'Alacty',   'ffxiv/sch/deployment_tactics' }, -- shares B - reduce cast
+  { 'battle 4 7',  'ja', 'Addendum: White', 'me',   'Add.Wht',  'ffxiv/sch/excogitation' },
+  { 'battle 4 7',  'ja', 'Addendum: Black', 'me',   'Add.Blk',  'ffxiv/sch/recitation' },
+  { 'battle 4 8',  'ja', 'Accession',       'me',   'Accssn',   'ffxiv/sch/protraction' },   -- shares C - extend
+  { 'battle 4 8',  'ja', 'Manifestation',   'me',   'Manifst',  'ffxiv/sch/biolysis' },      -- shares C - extend
+  { 'battle 4 9',  'ja', 'Rapture',         'me',   'Raptur',   'ffxiv/sch/art_of_war_II' }, -- shares D - mastery - potency
+  { 'battle 4 9',  'ja', 'Ebullience',      'me',   'Ebull',    'ffxiv/sch/art_of_war' },    -- Shares D - mastery - potency
   -- Storms
-  { 'battle 4 1',  'me', 'Sandstorm',       'stpc', 'Sand',     'ffxiv/whm/stone_II' },
-  { 'battle 4 2',  'me', 'Rainstorm',       'stpc', 'Rain',     'ffxiv/whm/fluid_aura' },
-  { 'battle 4 3',  'me', 'Windstorm',       'stpc', 'Wind',     'ffxiv/whm/aero_II' },
-  { 'battle 4 4',  'me', 'Firestorm',       'stpc', 'Fire',     'ffxiv/blm/fire_IV' },
-  { 'battle 4 5',  'me', 'Hailstorm',       'stpc', 'Hail',     'ffxiv/blm/blizzard_II' },
-  { 'battle 4 6',  'me', 'Thunderstorm',    'stpc', 'Thdr',     'ffxiv/blm/thunder_IV' },
-  { 'battle 4 7',  'me', 'Voidstorm',       'stpc', 'Void',     'ffxiv/ast/malefic_III' },
-  { 'battle 4 8',  'me', 'Aurorastorm',     'stpc', 'Aurora',   'ffxiv/whm/glare' },
+  { 'battle 3 4',  'me', 'Sandstorm',       'stpc', 'Sand',     'ffxiv/whm/stone_II' },
+  { 'battle 3 5',  'me', 'Rainstorm',       'stpc', 'Rain',     'ffxiv/whm/fluid_aura' },
+  { 'battle 3 6',  'me', 'Windstorm',       'stpc', 'Wind',     'ffxiv/whm/aero_II' },
+  { 'battle 3 7',  'me', 'Firestorm',       'stpc', 'Fire',     'ffxiv/blm/fire_IV' },
+  { 'battle 3 8',  'me', 'Hailstorm',       'stpc', 'Hail',     'ffxiv/blm/blizzard_II' },
+  { 'battle 3 9',  'me', 'Thunderstorm',    'stpc', 'Thdr',     'ffxiv/blm/thunder_IV' },
+  { 'battle 3 10', 'me', 'Voidstorm',       'stpc', 'Void',     'ffxiv/ast/malefic_III' },
+  { 'battle 3 11', 'me', 'Aurorastorm',     'stpc', 'Aurora',   'ffxiv/whm/glare' },
   -- Buffs (good in either art)
-  { 'battle 3 4',  'ma', 'Blink',           'me',   'Blink' },
-  { 'battle 3 5',  'ma', 'Stoneskin',       'me',   'Stoneskin' },
-  { 'battle 3 6',  'ma', 'Aquaveil',        'me',   'Aquaveil' },
+  { 'battle 4 2',  'ma', 'Blink',           'me',   'Blink' },
+  { 'battle 4 3',  'ma', 'Stoneskin',       'me',   'Stoneskin' },
+  { 'battle 4 1',  'ma', 'Aquaveil',        'me',   'Aquaveil' },
 }
 
 xivhotbar_keybinds_job['Light Arts'] = {
@@ -499,74 +496,74 @@ xivhotbar_keybinds_job['Light Arts'] = {
   { 'battle 3 2', 'ma', 'Regen II',  'stpc', 'Regen2' },
   { 'battle 3 2', 'ma', 'Regen III', 'stpc', 'Regen3' }, -- mastery
   -- Status Removal
-  { 'battle 3 3', 'ma', 'Poisona',   'stpc', 'Poisona' },
-  { 'battle 3 3', 'ma', 'Paralyna',  'stpc', 'Paralyna' },
-  { 'battle 3 3', 'ma', 'Blindna',   'stpc', 'Blindna' },
-  { 'battle 3 3', 'ma', 'Silena',    'stpc', 'Silena' },
-  { 'battle 3 3', 'ma', 'Cursna',    'stpc', 'Cursna' },
-  { 'battle 3 3', 'ma', 'Viruna',    'stpc', 'Viruna' },
-  { 'battle 3 3', 'ma', 'Stona',     'stpc', 'Stona' }, -- mastery
+  -- { 'battle 3 2', 'ma', 'Poisona',   'stpc', 'Poisona' },
+  -- { 'battle 3 2', 'ma', 'Paralyna',  'stpc', 'Paralyna' },
+  -- { 'battle 3 2', 'ma', 'Blindna',   'stpc', 'Blindna' },
+  -- { 'battle 3 2', 'ma', 'Silena',    'stpc', 'Silena' },
+  -- { 'battle 3 2', 'ma', 'Cursna',    'stpc', 'Cursna' },
+  -- { 'battle 3 2', 'ma', 'Viruna',    'stpc', 'Viruna' },
+  -- { 'battle 3 2', 'ma', 'Stona',     'stpc', 'Stona' }, -- mastery
   { 'battle 3 3', 'ma', 'Erase',     'stpc', 'Erase' },
 }
 
 xivhotbar_keybinds_job['Dark Arts'] = {
   -- Black Magic
-  -- { 'battle 1 1',  'ma', 'Stone',        't',     'Stone' },
-  -- { 'battle 1 1',  'ma', 'Stone II',     't',     'Stone2' },
-  -- { 'battle 1 1',  'ma', 'Stone III',    't',     'Stone3' }, -- mastery
-  -- { 'battle 1 2',  'ma', 'Water',        't',     'Water' },
-  -- { 'battle 1 2',  'ma', 'Water II',     't',     'Water2' },
-  -- { 'battle 1 2',  'ma', 'Water III',    't',     'Water3' }, -- mastery
-  -- { 'battle 1 3',  'ma', 'Aero',         't',     'Aero' },
-  -- { 'battle 1 3',  'ma', 'Aero II',      't',     'Aero2' },
-  -- { 'battle 1 4',  'ma', 'Fire',         't',     'Fire' },
-  -- { 'battle 1 4',  'ma', 'Fire II',      't',     'Fire2' },
-  -- { 'battle 1 5',  'ma', 'Blizzard',     't',     'Blizz' },
-  -- { 'battle 1 5',  'ma', 'Blizzard II',  't',     'Blizz2' },
-  -- { 'battle 1 6',  'ma', 'Thunder',      't',     'Thund' },
-  -- { 'battle 1 6',  'ma', 'Thunder II',   't',     'Thund2' }, -- mastery
+  -- { 'battle 3 ', 'ma', 'Stone III',    'stnpc', 'Stone3' }, -- mastery
+  -- { 'battle 3 ', 'ma', 'Stone II',     'stnpc', 'Stone2' },
+  -- { 'battle 3 ', 'ma', 'Stone',        'stnpc', 'Stone' },
+  -- { 'battle 3 ', 'ma', 'Water III',    'stnpc', 'Water3' }, -- mastery
+  -- { 'battle 3 ', 'ma', 'Water II',     'stnpc', 'Water2' },
+  -- { 'battle 3 ', 'ma', 'Water',        'stnpc', 'Water' },
+  -- { 'battle 3 ', 'ma', 'Aero II',      'stnpc', 'Aero2' },
+  -- { 'battle 3 ', 'ma', 'Aero',         'stnpc', 'Aero' },
+  -- { 'battle 3 ', 'ma', 'Fire II',      'stnpc', 'Fire2' },
+  -- { 'battle 3 ', 'ma', 'Fire',         'stnpc', 'Fire' },
+  -- { 'battle 3 ', 'ma', 'Blizzard II',  'stnpc', 'Blizz2' },
+  -- { 'battle 3 ', 'ma', 'Blizzard',     'stnpc', 'Blizz' },
+  -- { 'battle 3 ', 'ma', 'Thunder II',   'stnpc', 'Thund2' }, -- mastery
+  -- { 'battle 3 ', 'ma', 'Thunder',      'stnpc', 'Thund' },
   -- Enfeeblement
-  -- { 'battle 3 7',  'ma', 'Sleep',        'stnpc', 'Sleep' },
-  { 'battle 3 1', 'ma', 'Dispel',       'stnpc', 'Dispel' },
+  -- { 'battle 3 ', 'ma', 'Sleep',        'stnpc', 'Sleep' },
+  -- { 'battle 3 ', 'ma', 'Dispel',       'stnpc', 'Dispel' },
   -- Buffs
-  -- { 'battle 3 11', 'ma', 'Klimaform',    'me',    'Klima' },
-  { 'battle 3 3', 'ma', 'Blaze Spikes', 'me',    'B. Spikes' },
-  { 'battle 3 3', 'ma', 'Ice Spikes',   'me',    'I. Spikes' }, -- mastery
+  { 'battle 3 3', 'ma', 'Klimaform', 'me',    'Klima' },
+  -- { 'battle 3 ', 'ma', 'Blaze Spikes', 'me',    'B. Spikes' },
+  -- { 'battle 3 ', 'ma', 'Ice Spikes',   'me',    'I. Spikes' }, -- mastery
   -- Helix
-  -- { 'battle 2 1',  'ma', 'Geohelix',     't',     'Geo' },
-  -- { 'battle 2 2',  'ma', 'Hydrohelix',   't',     'Hydro' },
-  -- { 'battle 2 3',  'ma', 'Anemohelix',   't',     'Anemo' },
-  -- { 'battle 2 4',  'ma', 'Pyrohelix',    't',     'Pyro' },
-  -- { 'battle 2 5',  'ma', 'Cryohelix',    't',     'Cryo' },
-  -- { 'battle 2 6',  'ma', 'Ionohelix',    't',     'Iono' },
-  -- { 'battle 2 7',  'ma', 'Noctohelix',   't',     'Nocto' },
-  -- { 'battle 2 8',  'ma', 'Luminohelix',  't',     'Lumino' },
+  -- { 'battle 3 ', 'ma', 'Geohelix',     'stnpc', 'Geo' },
+  -- { 'battle 3 ', 'ma', 'Hydrohelix',   'stnpc', 'Hydro' },
+  -- { 'battle 3 ', 'ma', 'Anemohelix',   'stnpc', 'Anemo' },
+  -- { 'battle 3 ', 'ma', 'Pyrohelix',    'stnpc', 'Pyro' },
+  { 'battle 3 1', 'ma', 'Cryohelix', 'stnpc', 'Cryo' },
+  { 'battle 3 2', 'ma', 'Ionohelix', 'stnpc', 'Iono' },
+  -- { 'battle 3 ', 'ma', 'Noctohelix',   'stnpc', 'Nocto' },
+  -- { 'battle 3 ', 'ma', 'Luminohelix',  'stnpc', 'Lumino' },
   -- Absorb
-  -- { 'battle 3 9',  'ma', 'Drain',        't',     'Drain' },
-  { 'battle 3 2', 'ma', 'Aspir',        't',     'Aspir' },
+  -- { 'battle 3 ', 'ma', 'Drain',        'stnpc', 'Drain' },
+  -- { 'battle 3 ', 'ma', 'Aspir',        'stnpc', 'Aspir' },
 }
 
 -- WEAPONSKILL SETS (12)
 xivhotbar_keybinds_job['Club'] = {
   -- Heavy Hit
-  { 'battle 1 12', 'ws', 'True Strike',    't',  'True' },
+  { 'battle 1 12', 'ws', 'True Strike',    't', 'True' },
   -- { 'battle 1 1',  'ws', 'Judgment',       't', 'Judgment' }, -- war whm pld drk sam blu geo
   -- Multi-Hit
   -- { 'battle 1 2',  'ws', 'Hexa Strike',    't', 'Hexa' },     -- whm geo
-  { 'battle 1 12', 'ws', 'Black Halo',     't',  'Bl Halo' }, -- war mnk whm blm pld smn blu sch geo
+  { 'battle 1 12', 'ws', 'Black Halo',     't', 'Bl Halo' }, -- war mnk whm blm pld smn blu sch geo
   -- Light
-  { 'battle 1 12', 'ws', 'Shining Strike', 't',  'Shining' },
+  { 'battle 1 12', 'ws', 'Shining Strike', 't', 'Shining' },
   -- { 'battle 1 3',  'ws', 'Seraph Strike',  't', 'Seraph' },  -- war whm pld drk sam blu geo
   -- { 'battle 1 3',  'ws', 'Flash Nova',     't', 'Fl Nova' }, -- war whm pld drk sam blu geo
   -- Specials
-  { 'battle 1 12', 'ws', 'Skullbreaker',   't',  'Skullbrk' },
-  { 'battle 1 12', 'ws', 'Starlight',      'me', 'Star' },
-  -- { 'battle 1 5',  'ws', 'Moonlight',      'me', 'Moon' },     -- war whm pld drk sam blu geo
+  { 'battle 1 12', 'ws', 'Skullbreaker',   't', 'Skullbrk' },
+  { 'battle 1 12', 'ws', 'Starlight',      't', 'Star' },
+  -- { 'battle 1 5',  'ws', 'Moonlight',      't', 'Moon' },     -- war whm pld drk sam blu geo
   -- Class Specific
   -- { 'battle 1 6',  'ws', 'Mystic Boon',    't', 'Mystic' },   -- whm only
   -- { 'battle 1 6',  'ws', 'Exudation',      't', 'Exuda' },    -- geo
   -- Merit Point
-  { 'battle 1 12', 'ws', 'Realmrazer',     't',  'Realmrzr' }, -- war mnk whm blm pld smn blu sch geo
+  { 'battle 1 12', 'ws', 'Realmrazer',     't', 'Realmrzr' }, -- war mnk whm blm pld smn blu sch geo
   -- Empyrean (Abyssea only)  #9
   -- { 'battle 1 9',  'ws', 'Dagan',          't', 'Dagan' },    -- whm
   -- Relic & Prime (only usable with specific weapon equips) #10
@@ -575,7 +572,7 @@ xivhotbar_keybinds_job['Club'] = {
   -- AoE Ws #11
   -- none
   -- Stun WS #12
-  { 'battle 1 12', 'ws', 'Brainshaker',    't',  'Brainshkr' },
+  { 'battle 1 12', 'ws', 'Brainshaker',    't', 'Brainshkr' },
 }
 
 xivhotbar_keybinds_job['Staff'] = {

--- a/data/Examples/subjobs.lua
+++ b/data/Examples/subjobs.lua
@@ -70,9 +70,9 @@ xivhotbar_keybinds_job['DNC'] = {
   { 'battle 3 6',  'ja', 'Healing Waltz',     'stpc',  'Healing',  'ffxiv/dnc/shield_samba' },
   { 'battle 3 6',  'ja', 'Contradance',       'me',    'Contra',   'ffxiv/dnc/tillana' }, -- mastery
   -- Steps
-  { 'battle 3 7',  'ja', 'Quickstep',         'stnpc', 'Quick',    'ffxiv/dnc/en_avant' },
-  { 'battle 3 8',  'ja', 'Box Step',          'stnpc', 'Box',      'ffxiv/dnc/bladeshower' },
-  { 'battle 3 9',  'ja', 'Stutter Step',      'stnpc', 'Stutter',  'ffxiv/dnc/fountainfall' },
+  { 'battle 3 7',  'ja', 'Quickstep',         't',     'Quick',    'ffxiv/dnc/en_avant' },
+  { 'battle 3 8',  'ja', 'Box Step',          't',     'Box',      'ffxiv/dnc/bladeshower' },
+  { 'battle 3 9',  'ja', 'Stutter Step',      't',     'Stutter',  'ffxiv/dnc/fountainfall' },
   -- Flourishes
   { 'battle 3 10', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
   { 'battle 3 11', 'ja', 'Violent Flourish',  'stnpc', 'Stun',     'ffxiv/dnc/starfall_dance' },
@@ -104,8 +104,8 @@ xivhotbar_keybinds_job['NIN'] = {
 
   -- Enfeeblement
   { 'battle 3 3',  'ma', 'Kurayami: Ichi', 'stnpc', 'Kura',      'ffxiv/blu/glower' },      -- blind
-  { 'battle 3 4',  'ma', 'Hojo: Ni',       'stnpc', 'Hojo',      'ffxiv/ast/redraw' },      -- slow
   { 'battle 3 4',  'ma', 'Hojo: Ichi',     'stnpc', 'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 4',  'ma', 'Hojo: Ni',       'stnpc', 'Hojo',      'ffxiv/ast/redraw' },      -- slow
   { 'battle 3 5',  'ma', 'Dokumori: Ichi', 'stnpc', 'Doku',      'ffxiv/blu/exuviation' },  -- poison
   { 'battle 3 6',  'ma', 'Jubaku: Ichi',   'stnpc', 'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
   -- Stances
@@ -180,15 +180,15 @@ xivhotbar_keybinds_job['DRK'] = {
   { 'battle 3 7', 'ma', 'Absorb-STR',    'stnpc', 'Abs-STR' },
   { 'battle 3 7', 'ma', 'Absorb-TP',     'stnpc', 'Abs-TP' },
   -- Black Magic
-  { 'battle 3 1', 'ma', 'Stone',         'stnpc', 'Stone' },
-  { 'battle 3 1', 'ma', 'Stone II',      'stnpc', 'Stone2' },
-  { 'battle 3 1', 'ma', 'Water',         'stnpc', 'Water' },
-  { 'battle 3 1', 'ma', 'Water II',      'stnpc', 'Water2' },
-  { 'battle 3 1', 'ma', 'Aero',          'stnpc', 'Aero' },
-  { 'battle 3 1', 'ma', 'Aero II',       'stnpc', 'Aero2' }, -- mastery
-  { 'battle 3 1', 'ma', 'Fire',          'stnpc', 'Fire' },
-  { 'battle 3 1', 'ma', 'Blizzard',      'stnpc', 'Blizzard' },
-  { 'battle 3 1', 'ma', 'Thunder',       'stnpc', 'Thunder' },
+  { 'battle 5 1', 'ma', 'Stone',         'stnpc', 'Stone' },
+  { 'battle 5 1', 'ma', 'Stone II',      'stnpc', 'Stone2' },
+  { 'battle 5 1', 'ma', 'Water',         'stnpc', 'Water' },
+  { 'battle 5 1', 'ma', 'Water II',      'stnpc', 'Water2' },
+  { 'battle 5 1', 'ma', 'Aero',          'stnpc', 'Aero' },
+  { 'battle 5 1', 'ma', 'Aero II',       'stnpc', 'Aero2' }, -- mastery
+  { 'battle 5 1', 'ma', 'Fire',          'stnpc', 'Fire' },
+  { 'battle 5 1', 'ma', 'Blizzard',      'stnpc', 'Blizzard' },
+  { 'battle 5 1', 'ma', 'Thunder',       'stnpc', 'Thunder' },
 }
 
 xivhotbar_keybinds_job['RNG'] = {
@@ -324,8 +324,6 @@ xivhotbar_keybinds_job['WHM'] = {
   { 'battle 3 6',  'ma', 'Barvira',      'me',    'Vira' },
   { 'battle 3 9',  'ma', 'Barpetra',     'me',    'Petra' },
   -- Atk
-  { 'battle 3 5',  'ma', 'Banish',       'stnpc', 'Banish' },
-  { 'battle 3 5',  'ma', 'Banish II',    'stnpc', 'Banish2' },
   { 'battle 3 9',  'ma', 'Holy',         'stnpc', 'Holy' }, -- mastery
   -- Regen
   { 'battle 3 11', 'ma', 'Regen',        'stpc',  'Regen' },
@@ -354,77 +352,6 @@ xivhotbar_keybinds_job['WHM'] = {
   { 'battle 3 4',  'ma', 'Stona',        'stpc',  'Stona' },
   { 'battle 3 5',  'ma', 'Haste',        'stpc',  'Haste' },
   { 'battle 3 9',  'ma', 'Auspice',      'me',    'Ausp' }, -- mastery
-}
-
-xivhotbar_keybinds_job['BLM'] = {
-  -- Abilities
-  { 'battle 2 9',  'ja', 'Elemental Seal', 'me',    'E Seal',   'ffxiv/blm/foul' },
-  -- Elemental
-  { 'battle 3 2',  'ma', 'Stone',          'stnpc', 'Stone' },
-  { 'battle 3 2',  'ma', 'Stone II',       'stnpc', 'Stone2' },
-  { 'battle 3 2',  'ma', 'Stone III',      'stnpc', 'Stone3' }, -- mastery
-  { 'battle 3 2',  'ma', 'Water',          'stnpc', 'Water' },
-  { 'battle 3 2',  'ma', 'Water II',       'stnpc', 'Water2' },
-  { 'battle 3 2',  'ma', 'Water III',      'stnpc', 'Water3' }, -- mastery
-  { 'battle 3 2',  'ma', 'Aero',           'stnpc', 'Aero' },
-  { 'battle 3 2',  'ma', 'Aero II',        'stnpc', 'Aero2' },
-  { 'battle 3 2',  'ma', 'Aero III',       'stnpc', 'Aero3' }, -- mastery
-  { 'battle 3 2',  'ma', 'Fire',           'stnpc', 'Fire' },
-  { 'battle 3 2',  'ma', 'Fire II',        'stnpc', 'Fire2' },
-  { 'battle 3 2',  'ma', 'Blizzard',       'stnpc', 'Blizzard' },
-  { 'battle 3 2',  'ma', 'Blizzard II',    'stnpc', 'Blizzard2' },
-  { 'battle 3 2',  'ma', 'Thunder',        'stnpc', 'Thunder' },
-  { 'battle 3 2',  'ma', 'Thunder II',     'stnpc', 'Thunder2' },
-  { 'battle 3 2',  'ma', 'Drain',          'stpc',  'Drain' },
-  { 'battle 3 2',  'ma', 'Aspir',          'stpc',  'Aspir' },
-  -- Elemental AoE
-  { 'battle 3 2',  'ma', 'Stonega',        'stnpc', 'Stga' },
-  { 'battle 3 2',  'ma', 'Stonega II',     'stnpc', 'Stga2' },
-  { 'battle 3 2',  'ma', 'Waterga',        'stnpc', 'Waga' },
-  { 'battle 3 2',  'ma', 'Waterga II',     'stnpc', 'Waga2' },
-  { 'battle 3 2',  'ma', 'Aeroga',         'stnpc', 'Aega' },
-  { 'battle 3 2',  'ma', 'Aeroga II',      'stnpc', 'Aega2' },
-  { 'battle 3 2',  'ma', 'Firaga',         'stnpc', 'Figa' },
-  { 'battle 3 2',  'ma', 'Firaga II',      'stnpc', 'Figa2' }, -- mastery
-  { 'battle 3 2',  'ma', 'Blizzaga',       'stnpc', 'Blga' },
-  { 'battle 3 2',  'ma', 'Blizzaga II',    'stnpc', 'Blga2' }, -- mastery
-  { 'battle 3 2',  'ma', 'Thundaga',       'stnpc', 'Thga' },
-  -- Ancient Magic
-  { 'battle 3 2',  'ma', 'Freeze',         'stnpc', 'Freeze' },  -- mastery
-  { 'battle 3 2',  'ma', 'Tornado',        'stnpc', 'Tornado' }, -- mastery
-  { 'battle 3 2',  'ma', 'Quake',          'stnpc', 'Quake' },   -- mastery
-  { 'battle 3 2',  'ma', 'Burst',          'stnpc', 'Burst' },   -- mastery
-  { 'battle 3 2',  'ma', 'Flood',          'stnpc', 'Flood' },   -- mastery
-  -- Elemental DoTs
-  { 'battle 3 10', 'ma', 'Shock',          'stpc',  'Shock' },
-  { 'battle 3 5',  'ma', 'Rasp',           'stpc',  'Rasp' },
-  { 'battle 3 7',  'ma', 'Frost',          'stpc',  'Frost' },
-  { 'battle 3 6',  'ma', 'Choke',          'stpc',  'Choke' },
-  { 'battle 3 8',  'ma', 'Burn',           'stpc',  'Burn' },
-  { 'battle 3 9',  'ma', 'Drown',          'stpc',  'Drown' },
-  -- Enfeeblement
-  { 'battle 3 2',  'ma', 'Poison',         't',     'Poison' },
-  { 'battle 3 2',  'ma', 'Poison II',      't',     'Poison2' },
-  { 'battle 3 2',  'ma', 'Poisonga',       'stpc',  'Psnga' },
-  { 'battle 3 3',  'ma', 'Blind',          't',     'Blind' },
-  { 'battle 3 4',  'ma', 'Bind',           'stnpc', 'Bind' },
-  { 'battle 3 1',  'ma', 'Bio',            't',     'Bio' },
-  { 'battle 3 1',  'ma', 'Bio II',         't',     'Bio2' },
-  { 'battle 3 2',  'ma', 'Sleep',          'stnpc', 'Sleep' },
-  { 'battle 3 2',  'ma', 'Sleep II',       'stnpc', 'Sleep2' }, -- mastery
-  { 'battle 1 12', 'ma', 'Stun',           't',     'Stun' },
-  { 'battle 3 5',  'ma', 'Sleepga',        'stnpc', 'Sleepga' },
-  { 'battle 3 6',  'ma', 'Sleepga II',     'stnpc', 'Sleepga2' }, -- mastery
-  -- Spikes
-  { 'battle 3 2',  'ma', 'Blaze Spikes',   'me',    'BlzSpk' },
-  { 'battle 3 2',  'ma', 'Ice Spikes',     'me',    'IceSpk' },
-  { 'battle 3 2',  'ma', 'Shock Spikes',   'me',    'ShkSpk' },
-  -- Utility
-  { 'battle 3 11', 'ma', 'Tractor',        'stpc',  'Tractor' },
-  { 'battle 3 2',  'ma', 'Escape',         'me',    'Escape' },
-  { 'battle 3 2',  'ma', 'Warp',           'me',    'Warp' },
-  { 'battle 3 2',  'ma', 'Warp II',        'stnc',  'Warp2' },
-  { 'battle 3 2',  'ma', 'Retrace',        'stnc',  'Retrace' }, -- mastery
 }
 
 -- ================================================================================
@@ -677,7 +604,7 @@ xivhotbar_keybinds_job['PLD'] = {
 xivhotbar_keybinds_job['PUP'] = {
   -- Pet Control
   { 'battle 3 1',  'ja', 'Deploy',           't',  'Fight',    'ffxiv/mch/rook_overload' },
-  { 'battle 3 2',  'ja', 'Retrieve',         'me', 'Retrieve', 'ffxiv/mch/pile_bunker' },
+  { 'battle 3 2',  'ja', 'Retrieve',         't',  'Retrieve', 'ffxiv/mch/pile_bunker' },
   -- Maneuvers
   { 'battle 3 3',  'ja', 'Fire Maneuver',    'me', 'FireMan',  'ffxiv/pic/fire_in_red' },
   { 'battle 3 4',  'ja', 'Ice Maneuver',     'me', 'IceMan',   'ffxiv/pic/blizzard_in_cyan' },

--- a/data/Examples/thf.lua
+++ b/data/Examples/thf.lua
@@ -84,8 +84,8 @@ xivhotbar_keybinds_job['COR'] = {
 
 xivhotbar_keybinds_job['NIN'] = {
   -- Shadows
-  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me', 'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
-  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me', 'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
+  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me',    'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
+  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me',    'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
   -- Elements
   -- {'battle 3 7', 'ma', 'Katon: Ni', 'stnpc', 'Katon2','ffxiv/nin/katon'}, -- fire
   -- {'battle 3 7', 'ma', 'Katon: Ichi', 'stnpc', 'Katon','ffxiv/nin/katon'}, -- fire
@@ -100,38 +100,38 @@ xivhotbar_keybinds_job['NIN'] = {
   -- {'battle 3 12', 'ma', 'Raiton: Ni', 'stnpc', 'Raiton2','ffxiv/nin/raiton'}, -- thunder
   -- {'battle 3 12', 'ma', 'Raiton: Ichi', 'stnpc', 'Raiton','ffxiv/nin/raiton'}, -- thunder
   -- Enfeeblement
-  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 't',  'Kura',      'ffxiv/blu/glower' },      -- blind
-  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 't',  'Doku',      'ffxiv/blu/exuviation' },  -- poison
-  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   't',  'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
+  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 'stnpc', 'Kura',      'ffxiv/blu/glower' },      -- blind
+  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 'stnpc', 'Doku',      'ffxiv/blu/exuviation' },  -- poison
+  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   'stnpc', 'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
   -- Stances
-  { 'battle 3 11', 'ja', 'Yonin',          'me', 'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
-  { 'battle 3 12', 'ja', 'Innin',          'me', 'Innin',     'ffxiv/nin/assassinate' }, -- dps
+  { 'battle 3 11', 'ja', 'Yonin',          'me',    'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
+  { 'battle 3 12', 'ja', 'Innin',          'me',    'Innin',     'ffxiv/nin/assassinate' }, -- dps
 }
 
 xivhotbar_keybinds_job['DNC'] = {
   -- Sambas
-  { 'battle 3 1',  'ja', 'Haste Samba',       'me',   'Haste',    'ffxiv/dnc/pirouette' },
-  { 'battle 3 2',  'ja', 'Drain Samba',       'me',   'Drain',    'ffxiv/dnc/emboite' },
-  { 'battle 3 2',  'ja', 'Drain Samba II',    'me',   'Drain2',   'ffxiv/dnc/emboite' },
+  { 'battle 3 1',  'ja', 'Haste Samba',       'me',    'Haste',    'ffxiv/dnc/pirouette' },
+  { 'battle 3 2',  'ja', 'Drain Samba',       'me',    'Drain',    'ffxiv/dnc/emboite' },
+  { 'battle 3 2',  'ja', 'Drain Samba II',    'me',    'Drain2',   'ffxiv/dnc/emboite' },
   -- {'battle 3 3', 'ja', 'Aspir Samba', 'me', 'Aspir','ffxiv/dnc/jete'},
   -- Waltzes
-  { 'battle 3 3',  'ja', 'Curing Waltz',      'stpc', 'CurW',     'ffxiv/dnc/curing_waltz' },
-  { 'battle 3 3',  'ja', 'Curing Waltz II',   'stpc', 'CurW2',    'ffxiv/dnc/curing_waltz' },
-  { 'battle 3 3',  'ja', 'Curing Waltz III',  'stpc', 'CurW3',    'ffxiv/dnc/curing_waltz' },
-  { 'battle 3 4',  'ja', 'Divine Waltz',      'stpc', 'Divine',   'ffxiv/dnc/improvised_finish' },
-  { 'battle 3 5',  'ja', 'Healing Waltz',     'stpc', 'Healing',  'ffxiv/dnc/shield_samba' },
-  { 'battle 3 8',  'ja', 'Contradance',       'me',   'Contra',   'ffxiv/dnc/tillana' }, -- mastery
+  { 'battle 3 3',  'ja', 'Curing Waltz',      'stpc',  'CurW',     'ffxiv/dnc/curing_waltz' },
+  { 'battle 3 3',  'ja', 'Curing Waltz II',   'stpc',  'CurW2',    'ffxiv/dnc/curing_waltz' },
+  { 'battle 3 3',  'ja', 'Curing Waltz III',  'stpc',  'CurW3',    'ffxiv/dnc/curing_waltz' },
+  { 'battle 3 4',  'ja', 'Divine Waltz',      'stpc',  'Divine',   'ffxiv/dnc/improvised_finish' },
+  { 'battle 3 5',  'ja', 'Healing Waltz',     'stpc',  'Healing',  'ffxiv/dnc/shield_samba' },
+  { 'battle 3 8',  'ja', 'Contradance',       'me',    'Contra',   'ffxiv/dnc/tillana' }, -- mastery
   -- Steps
-  { 'battle 3 6',  'ja', 'Quickstep',         't',    'Quick',    'ffxiv/dnc/en_avant' },
-  { 'battle 3 7',  'ja', 'Box Step',          't',    'Box',      'ffxiv/dnc/bladeshower' },
+  { 'battle 3 6',  'ja', 'Quickstep',         't',     'Quick',    'ffxiv/dnc/en_avant' },
+  { 'battle 3 7',  'ja', 'Box Step',          't',     'Box',      'ffxiv/dnc/bladeshower' },
   -- {'battle 3 9', 'ja', 'Stutter Step', 't', 'Stutter','ffxiv/dnc/fountainfall'},
   -- Flourishes
-  { 'battle 3 12', 'ja', 'Animated Flourish', 't',    'Voke',     'ffxiv/dnc/closed_position' },
-  { 'battle 3 9',  'ja', 'Violent Flourish',  't',    'Stun',     'ffxiv/dnc/starfall_dance' },
-  { 'battle 3 10', 'ja', 'Reverse Flourish',  'me',   'Reverse',  'ffxiv/dnc/reverse_cascade' },
-  { 'battle 3 11', 'ja', 'Building Flourish', 'me',   'Building', 'ffxiv/dnc/flourish' },
+  { 'battle 3 12', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
+  { 'battle 3 9',  'ja', 'Violent Flourish',  'stnpc', 'Stun',     'ffxiv/dnc/starfall_dance' },
+  { 'battle 3 10', 'ja', 'Reverse Flourish',  'me',    'Reverse',  'ffxiv/dnc/reverse_cascade' },
+  { 'battle 3 11', 'ja', 'Building Flourish', 'me',    'Building', 'ffxiv/dnc/flourish' },
   -- Jigs
   -- {'battle 3 8', 'ja', 'Spectral Jig', 'me', 'Spectral','ffxiv/dnc/fan_dance_IV'},
   -- {'battle 3 8', 'ja', 'Chocobo Jig', 'me', 'Chocobo','ffxiv/dnc/entrechat'}, -- mastery
@@ -150,8 +150,8 @@ xivhotbar_keybinds_job['DRK'] = {
   { 'battle 3 3', 'ja', 'Consume Mana',  'me',    'Consume', 'ffxiv/drk/syphon_strike' },
   { 'battle 3 4', 'ja', 'Weapon Bash',   't',     'Bash',    'ffxiv/drk/shadow_wall' },
   { 'battle 3 5', 'ja', 'Arcane Circle', 'me',    'Arcane',  'ffxiv/drk/salted_earth' },
-  { 'battle 3 6', 'ma', 'Bio',           't',     'Bio' },
-  { 'battle 3 6', 'ma', 'Bio II',        't',     'Bio2' },
+  { 'battle 3 6', 'ma', 'Bio',           'stnpc', 'Bio' },
+  { 'battle 3 6', 'ma', 'Bio II',        'stnpc', 'Bio2' },
   { 'battle 3 7', 'ma', 'Sleep',         'stnpc', 'Sleep' },
   { 'battle 3 7', 'ma', 'Sleep II',      'stnpc', 'Sleep2' },
   { 'battle 3 8', 'ma', 'Stun',          't',     'Stun' },

--- a/data/Examples/war.lua
+++ b/data/Examples/war.lua
@@ -21,7 +21,7 @@ xivhotbar_keybinds_job['Base'] = {
   --12 is always 2-hour ability
   { 'battle 4 3',  'ja',    'Defender',         'me',    'Defend',   'ffxiv/war/shake_it_off' },
   { 'battle 4 1',  'ja',    'Aggressor',        'me',    'Aggrsr',   'ffxiv/war/onslaught' },
-  { 'battle 4 2',  'ja',    'Retaliation',      't',     'Rtaliate', 'ffxiv/war/fell_cleave' },
+  { 'battle 4 2',  'ja',    'Retaliation',      'stnpc', 'Rtaliate', 'ffxiv/war/fell_cleave' },
   { 'battle 4 3',  'ja',    'Restraint',        'me',    'Restrnt',  'ffxiv/war/primal_rend' },
   { 'battle 4 3',  'ja',    'Blood Rage',       'me',    'Blood',    'ffxiv/war/bloodwhetting' },
   { 'battle 4 12', 'ja',    'Mighty Strikes',   'me',    'Mty Stk',  'ffxiv/war/holmgang' },
@@ -29,7 +29,7 @@ xivhotbar_keybinds_job['Base'] = {
   -- Hotbar #5
   { 'battle 5 1',  'input', '/ra <t>',          '',      'Pull',     'ra' },
   { 'battle 5 2',  'ja',    'Provoke',          't',     'Voke',     'ffxiv/war/defiance' },
-  { 'battle 5 3',  'ja',    'Tomahawk',         't',     'Tomahawk', 'ffxiv/war/tomahawk' },
+  { 'battle 5 3',  'ja',    'Tomahawk',         'stnpc', 'Tomahawk', 'ffxiv/war/tomahawk' },
 
   -- Hotbar #6
 }
@@ -37,12 +37,12 @@ xivhotbar_keybinds_job['Base'] = {
 -- SUBJOBS
 -- Hotbar #3
 xivhotbar_keybinds_job['MNK'] = {
-  { 'battle 3 1', 'ja', 'Boost',         'me', 'Boost',  'ffxiv/mnk/riddle_of_fire' },
-  { 'battle 3 2', 'ja', 'Dodge',         'me', 'Dodge',  'ffxiv/mnk/riddle_of_earth' },
-  { 'battle 3 3', 'ja', 'Focus',         'me', 'Focus',  'ffxiv/mnk/riddle_of_wind' },
-  { 'battle 3 4', 'ja', 'Chakra',        'me', 'Chakra', 'ffxiv/mnk/meditation' },
-  { 'battle 3 5', 'ja', 'Chi Blast',     't',  'Chi',    'ffxiv/mnk/elixir_field' },
-  { 'battle 3 6', 'ja', 'Counterstance', 'me', 'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
+  { 'battle 3 1', 'ja', 'Boost',         'me',    'Boost',  'ffxiv/mnk/riddle_of_fire' },
+  { 'battle 3 2', 'ja', 'Dodge',         'me',    'Dodge',  'ffxiv/mnk/riddle_of_earth' },
+  { 'battle 3 3', 'ja', 'Focus',         'me',    'Focus',  'ffxiv/mnk/riddle_of_wind' },
+  { 'battle 3 4', 'ja', 'Chakra',        'me',    'Chakra', 'ffxiv/mnk/meditation' },
+  { 'battle 3 5', 'ja', 'Chi Blast',     'stnpc', 'Chi',    'ffxiv/mnk/elixir_field' },
+  { 'battle 3 6', 'ja', 'Counterstance', 'me',    'Ctr',    'ffxiv/mnk/arm_of_the_destroyer' },
 }
 
 xivhotbar_keybinds_job['THF'] = {
@@ -81,8 +81,8 @@ xivhotbar_keybinds_job['COR'] = {
 
 xivhotbar_keybinds_job['NIN'] = {
   -- Shadows
-  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me', 'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
-  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me', 'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
+  { 'battle 3 1',  'ma', 'Utsusemi: Ichi', 'me',    'Utsu:Ichi', 'ffxiv/nin/dream_within_a_dream' },
+  { 'battle 3 2',  'ma', 'Utsusemi: Ni',   'me',    'Utsu:Ni',   'ffxiv/nin/phantom_kamaitachi' },
   -- Elements
   -- {'battle 3 7', 'ma', 'Katon: Ni', 'stnpc', 'Katon2','ffxiv/nin/katon'}, -- fire
   -- {'battle 3 7', 'ma', 'Katon: Ichi', 'stnpc', 'Katon','ffxiv/nin/katon'}, -- fire
@@ -97,14 +97,14 @@ xivhotbar_keybinds_job['NIN'] = {
   -- {'battle 3 12', 'ma', 'Raiton: Ni', 'stnpc', 'Raiton2','ffxiv/nin/raiton'}, -- thunder
   -- {'battle 3 12', 'ma', 'Raiton: Ichi', 'stnpc', 'Raiton','ffxiv/nin/raiton'}, -- thunder
   -- Enfeeblement
-  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 't',  'Kura',      'ffxiv/blu/glower' },      -- blind
-  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',  'Hojo',      'ffxiv/ast/redraw' },      -- slow
-  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 't',  'Doku',      'ffxiv/blu/exuviation' },  -- poison
-  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   't',  'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
+  { 'battle 3 3',  'ma', 'Kurayami: Ichi', 'stnpc', 'Kura',      'ffxiv/blu/glower' },      -- blind
+  { 'battle 3 4',  'ma', 'Hojo: Ni',       't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 4',  'ma', 'Hojo: Ichi',     't',     'Hojo',      'ffxiv/ast/redraw' },      -- slow
+  { 'battle 3 5',  'ma', 'Dokumori: Ichi', 'stnpc', 'Doku',      'ffxiv/blu/exuviation' },  -- poison
+  { 'battle 3 6',  'ma', 'Jubaku: Ichi',   'stnpc', 'Jubaku',    'ffxiv/blu/faze' },        -- paralyze
   -- Stances
-  { 'battle 3 11', 'ja', 'Yonin',          'me', 'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
-  { 'battle 3 12', 'ja', 'Innin',          'me', 'Innin',     'ffxiv/nin/assassinate' }, -- dps
+  { 'battle 3 11', 'ja', 'Yonin',          'me',    'Yonin',     'ffxiv/nin/shade_shift' }, -- tanky
+  { 'battle 3 12', 'ja', 'Innin',          'me',    'Innin',     'ffxiv/nin/assassinate' }, -- dps
 }
 
 xivhotbar_keybinds_job['DNC'] = {
@@ -121,12 +121,12 @@ xivhotbar_keybinds_job['DNC'] = {
   { 'battle 3 5',  'ja', 'Healing Waltz',     'stpc',  'Healing',  'ffxiv/dnc/shield_samba' },
   { 'battle 3 8',  'ja', 'Contradance',       'me',    'Contra',   'ffxiv/dnc/tillana' }, -- mastery
   -- Steps
-  { 'battle 3 6',  'ja', 'Quickstep',         't',     'Quick',    'ffxiv/dnc/en_avant' },
-  { 'battle 3 7',  'ja', 'Box Step',          't',     'Box',      'ffxiv/dnc/bladeshower' },
+  { 'battle 3 6',  'ja', 'Quickstep',         'stnpc', 'Quick',    'ffxiv/dnc/en_avant' },
+  { 'battle 3 7',  'ja', 'Box Step',          'stnpc', 'Box',      'ffxiv/dnc/bladeshower' },
   -- {'battle 3 9', 'ja', 'Stutter Step', 'stnpc', 'Stutter','ffxiv/dnc/fountainfall'},
   -- Flourishes
   { 'battle 3 12', 'ja', 'Animated Flourish', 'stnpc', 'Voke',     'ffxiv/dnc/closed_position' },
-  { 'battle 3 9',  'ja', 'Violent Flourish',  't',     'Stun',     'ffxiv/dnc/starfall_dance' },
+  { 'battle 3 9',  'ja', 'Violent Flourish',  'stnpc', 'Stun',     'ffxiv/dnc/starfall_dance' },
   { 'battle 3 10', 'ja', 'Reverse Flourish',  'me',    'Reverse',  'ffxiv/dnc/reverse_cascade' },
   { 'battle 3 11', 'ja', 'Building Flourish', 'me',    'Building', 'ffxiv/dnc/flourish' },
   -- Jigs
@@ -179,8 +179,8 @@ xivhotbar_keybinds_job['DRK'] = {
   { 'battle 3 3', 'ja', 'Consume Mana',  'me',    'Consume', 'ffxiv/drk/syphon_strike' },
   { 'battle 3 4', 'ja', 'Weapon Bash',   't',     'Bash',    'ffxiv/drk/shadow_wall' },
   { 'battle 3 5', 'ja', 'Arcane Circle', 'me',    'Arcane',  'ffxiv/drk/salted_earth' },
-  { 'battle 3 6', 'ma', 'Bio',           't',     'Bio' },
-  { 'battle 3 6', 'ma', 'Bio II',        't',     'Bio2' },
+  { 'battle 3 6', 'ma', 'Bio',           'stnpc', 'Bio' },
+  { 'battle 3 6', 'ma', 'Bio II',        'stnpc', 'Bio2' },
   { 'battle 3 7', 'ma', 'Sleep',         'stnpc', 'Sleep' },
   { 'battle 3 7', 'ma', 'Sleep II',      'stnpc', 'Sleep2' },
   { 'battle 3 8', 'ma', 'Stun',          't',     'Stun' },

--- a/data/Examples/weaponsets.lua
+++ b/data/Examples/weaponsets.lua
@@ -6,6 +6,9 @@
 -- Remember to modify bar-action locations to fit your needs!
 -- relic/empy/mythic/prime are weapon dependent barring quests. Adjust to fit your needs
 
+-- There are two sets for each weapon, one by category of skill type, and the other
+-- by skillchain property.
+
 xivhotbar_keybinds_job['Hand-to-hand'] = {
   -- Heavy Hit
   { 'battle 1 1',  'ws', 'One Inch Punch',   't', '1Inch' },  -- mnk pup
@@ -18,21 +21,56 @@ xivhotbar_keybinds_job['Hand-to-hand'] = {
   -- Specials
   { 'battle 1 3',  'ws', 'Howling Fist',     't', 'Howling' }, -- mnk pup
   { 'battle 1 4',  'ws', 'Tornado Kick',     't', 'Tornado' }, -- mnk pup
-  -- Class Specific
+  -- Prime #6
+  { 'battle 1 6',  'ws', 'Maru Kala',        't', 'Maru' },
+  -- Class Specific #7
   { 'battle 1 7',  'ws', "Ascetic's Fury",   't', 'Ascetic' }, -- mnk
   { 'battle 1 7',  'ws', 'Stringing Pummel', 't', 'String' },  -- pup
-  -- Merit Point
+  { 'battle 1 7',  'ws', 'name',             't', 'displayName' },
+  -- Merit Point #8
   { 'battle 1 8',  'ws', 'Shijin Spiral',    't', 'Shijin' },  -- mnk pup
   -- Empyrean (Abyssea only)  #9
   { 'battle 1 9',  'ws', 'Victory Smite',    't', 'Victory' }, -- mnk pup
-  -- Relic & Prime (only usable with specific weapon equips) #10
+  -- Relic (only usable with specific weapon equips) #10
   { 'battle 1 10', 'ws', 'Final Heaven',     't', 'FinHvn' },  -- mnk
   { 'battle 1 10', 'ws', 'Dragon Blow',      't', 'DragonB' }, -- bonanza
-  { 'battle 1 10', 'ws', 'Maru Kala',        't', 'Maru' },
   -- AoE Ws #11
   { 'battle 1 11', 'ws', 'Spinning Attack',  't', 'Spinning' },
   -- Stun WS #12
   { 'battle 1 12', 'ws', 'Shoulder Tackle',  't', 'Tackle' },
+}
+
+xivhotbar_keybinds_job['Hand-to-hand'] = {
+  -- Compression
+  { 'battle 1 1',  'ws', 'One Inch Punch',   't', '1Inch' }, -- mnk pup
+  -- Detonation
+  { 'battle 1 2',  'ws', 'Backhand Blow',    't', 'Backhand' },
+  -- Impaction
+  { 'battle 1 3',  'ws', 'Combo',            't', 'Combo' },
+  { 'battle 1 3',  'ws', 'Raging Fists',     't', 'Raging' }, -- mnk pup
+  -- Impaction / Reverberation
+  { 'battle 1 4',  'ws', 'Shoulder Tackle',  't', 'Tackle' },
+  -- Liquefaction / Impaction
+  { 'battle 1 5',  'ws', 'Spinning Attack',  't', 'Spinning' },
+  -- Transfixion / Impaction
+  { 'battle 1 6',  'ws', 'Howling Fist',     't', 'Howling' }, -- mnk pup
+  -- Induration / Impaction / Detonation
+  { 'battle 1 7',  'ws', 'Tornado Kick',     't', 'Tornado' }, -- mnk pup
+  -- Distortion
+  { 'battle 1 8',  'ws', 'Dragon Blow',      't', 'DragonB' }, -- bonanza
+  -- Fragmentation
+  { 'battle 1 9',  'ws', 'Dragon Kick',      't', 'Dragon' },  -- mnk pup
+  -- Fusion / Reverberation
+  { 'battle 1 10', 'ws', 'Shijin Spiral',    't', 'Shijin' },  -- mnk pup
+  -- Gravitation / Liquefaction
+  { 'battle 1 11', 'ws', 'Asuran Fists',     't', 'Asuran' },  -- mnk pup
+  { 'battle 1 12', 'ws', 'Stringing Pummel', 't', 'String' },  -- pup
+  -- Detonation / Compression / Distortion
+  { 'battle 1 1',  'ws', 'Maru Kala',        't', 'Maru' },
+  -- Light / Fragmentation
+  { 'battle 1 2',  'ws', 'Victory Smite',    't', 'Victory' }, -- mnk pup
+  -- Light / Fusion
+  { 'battle 1 3',  'ws', 'Final Heaven',     't', 'FinHvn' },  -- mnk
 }
 
 xivhotbar_keybinds_job['Dagger'] = {
@@ -47,23 +85,61 @@ xivhotbar_keybinds_job['Dagger'] = {
   { 'battle 1 3',  'ws', 'Gust Slash',      't', 'Gust' },
   -- Specials
   { 'battle 1 4',  'ws', 'Energy Steal',    't', 'Energy' },
-  { 'battle 1 4',  'ws', 'Energy Drain',    't', 'Energy' },   -- rdm thf brd rng nin dnc
-  -- Class Specific
+  { 'battle 1 4',  'ws', 'Energy Drain',    't', 'Energy' }, -- rdm thf brd rng nin dnc
+  -- Prime #6
+  { 'battle 1 6',  'ws', 'Ruthless Stroke', 't', 'Ruthless' },
+  -- Class Specific #7
   { 'battle 1 7',  'ws', 'Mandalic Stab',   't', 'Mandalic' }, -- thf
   { 'battle 1 7',  'ws', 'Mordant Rime',    't', 'Mordant' },  -- brd
   { 'battle 1 7',  'ws', 'Pyrrhic Kleos',   't', 'Pyrrhic' },  -- dnc
-  -- Merit Point
+  -- Merit Point #8
   { 'battle 1 8',  'ws', 'Exenterator',     't', 'Exent' },    -- war rdm thf bst brd rng nin cor dnc
   -- Empyrean (Abyssea only)  #9
   { 'battle 1 9',  'ws', "Rudra's Storm",   't', 'Rudra' },    -- thf brd dnc
-  -- Relic & Prime (only usable with specific weapon equips) #10
-  { 'battle 1 10', 'ws', 'Ruthless Stroke', 't', 'Ruthless' },
-  { 'battle 1 10', 'ws', 'Mercy Stroke',    't', 'Mercy' },   -- rdm thf brd dnc relic
+  -- Relic (only usable with specific weapon equips) #10
+  { 'battle 1 10', 'ws', 'Mercy Stroke',    't', 'Mercy' },    -- rdm thf brd dnc relic
   -- AoE Ws #11
-  { 'battle 1 11', 'ws', 'Cyclone',         't', 'Cyclone' }, -- rdm thf brd rng nin cor dnc
-  { 'battle 1 11', 'ws', 'Aeolian Edge',    't', 'Aeoln' },   -- rdm thf brd rng nin dnc
+  { 'battle 1 11', 'ws', 'Cyclone',         't', 'Cyclone' },  -- rdm thf brd rng nin cor dnc
+  { 'battle 1 11', 'ws', 'Aeolian Edge',    't', 'Aeoln' },    -- rdm thf brd rng nin dnc
   -- Bind WS #12
   { 'battle 1 12', 'ws', 'Shadowstitch',    't', 'ShdSt' },
+}
+
+xivhotbar_keybinds_job['Dagger'] = {
+  -- No Skillchain
+  { 'battle 1 1',  'ws', 'Energy Steal',    't', 'Energy' },
+  { 'battle 1 1',  'ws', 'Energy Drain',    't', 'Energy' }, -- rdm thf brd rng nin dnc
+  -- Detonation
+  { 'battle 1 2',  'ws', 'Gust Slash',      't', 'Gust' },
+  -- Reverberation
+  { 'battle 1 3',  'ws', 'Shadowstitch',    't', 'ShdSt' },
+  -- Scission
+  { 'battle 1 4',  'ws', 'Wasp Sting',      't', 'Wasp' },
+  { 'battle 1 4',  'ws', 'Viper Bite',      't', 'Viper' },    -- rdm thf brd rng nin dnc
+  -- Detonation / Impaction
+  { 'battle 1 5',  'ws', 'Cyclone',         't', 'Cyclone' },  -- rdm thf brd rng nin cor dnc
+  -- Scission / Detonation
+  { 'battle 1 6',  'ws', 'Dancing Edge',    't', 'DncEdge' },  -- thf dnc
+  -- Scission / Detonation / Impaction
+  { 'battle 1 7',  'ws', 'Aeolian Edge',    't', 'Aeoln' },    -- rdm thf brd rng nin dnc
+  -- Fragmentation
+  { 'battle 1 8',  'ws', 'Shark Bite',      't', 'Shark' },    -- thf dnc
+  -- Distortion / Scission
+  { 'battle 1 9',  'ws', 'Pyrrhic Kleos',   't', 'Pyrrhic' },  -- dnc
+  -- Fragmentation / Scission
+  { 'battle 1 10', 'ws', 'Exenterator',     't', 'Exent' },    -- war rdm thf bst brd rng nin cor dnc
+  -- Fusion / Compression
+  { 'battle 1 11', 'ws', 'Mandalic Stab',   't', 'Mandalic' }, -- thf
+  -- Gravitation / Transfixion
+  { 'battle 1 12', 'ws', 'Evisceration',    't', 'Evisc' },    -- war rdm thf bst brd rng nin cor dnc
+  -- Liquefaction / Impaction / Fragmentation
+  { 'battle 1 1',  'ws', 'Ruthless Stroke', 't', 'Ruthless' },
+  -- Fragmentation / Distortion
+  { 'battle 1 2',  'ws', 'Mordant Rime',    't', 'Mordant' }, -- brd
+  -- Darkness / Gravitation
+  { 'battle 1 3',  'ws', 'Mercy Stroke',    't', 'Mercy' },   -- rdm thf brd dnc relic
+  -- Darkness / Distortion
+  { 'battle 1 4',  'ws', "Rudra's Storm",   't', 'Rudra' },   -- thf brd dnc
 }
 
 xivhotbar_keybinds_job['Sword'] = {
@@ -99,6 +175,44 @@ xivhotbar_keybinds_job['Sword'] = {
   { 'battle 1 12', 'ws', 'Flat Blade',       't', 'Flat' },
 }
 
+xivhotbar_keybinds_job['Sword'] = {
+  -- No Skillchain
+  { 'battle 1 1',  'ws', 'Spirits Within',   't', 'Spirits' },
+  { 'battle 1 1',  'ws', 'Sanguine Blade',   't', 'Sanguine' }, -- war rdm pld drk blu run
+  -- Impaction
+  { 'battle 1 2',  'ws', 'Flat Blade',       't', 'Flat' },
+  -- Liquefaction
+  { 'battle 1 3',  'ws', 'Burning Blade',    't', 'Burning' },
+  -- Scission
+  { 'battle 1 4',  'ws', 'Fast Blade',       't', 'Fast' },
+  { 'battle 1 4',  'ws', 'Shining Blade',    't', 'Shining' },
+  { 'battle 1 4',  'ws', 'Seraph Blade',     't', 'Seraph' }, -- war rdm pld drk blu run sub
+  -- Liquefaction / Detonation
+  { 'battle 1 5',  'ws', 'Red Lotus Blade',  't', 'RLotus' }, -- war rdm pld drk blu
+  -- Reverberation / Impaction
+  { 'battle 1 6',  'ws', 'Circle Blade',     't', 'Circle' },
+  -- Scission / Impaction
+  { 'battle 1 7',  'ws', 'Vorpal Blade',     't', 'Vorpal' },   -- war rdm pld drk blu run
+  -- Gravitation
+  { 'battle 1 8',  'ws', 'Swift Blade',      't', 'Swift' },    -- pld run
+  -- Distortion / Scission
+  { 'battle 1 9',  'ws', 'Expiacion',        't', 'Expiacn' },  -- blu
+  -- Fragmentation / Scission
+  { 'battle 1 10', 'ws', 'Savage Blade',     't', 'Savage' },   -- war rdm pld drk blu cor run sub
+  -- Fusion / Reverberation
+  { 'battle 1 11', 'ws', 'Atonement',        't', 'Atone' },    -- pld
+  -- Gravitation / Scission
+  { 'battle 1 12', 'ws', 'Requiescat',       't', 'Requisct' }, -- war rdm pld drk sam blu cor run
+  -- Detonation / Compression / Distortion
+  { 'battle 1 1',  'ws', 'Imperator',        't', 'Imperator' },
+  -- Fragmentation / Distortion
+  { 'battle 1 2',  'ws', 'Death Blossom',    't', 'D Blsm' }, -- rdm
+  -- Light / Distortion
+  { 'battle 1 3',  'ws', 'Chant du Cygne',   't', 'duCygne' },
+  -- Light / Fusion
+  { 'battle 1 4',  'ws', 'Knights of Round', 't', 'KotR' }, -- rdm pld blu relic
+}
+
 xivhotbar_keybinds_job['Great Sword'] = {
   -- Heavy Hit
   { 'battle 1 1',  'ws', 'Hard Slash',      't', 'Hard' },
@@ -126,6 +240,38 @@ xivhotbar_keybinds_job['Great Sword'] = {
   -- none
   -- Sleep WS #12
   { 'battle 1 12', 'ws', 'Shockwave',       't', 'Shockwave' },
+}
+
+xivhotbar_keybinds_job['Great Sword'] = {
+  -- Induration
+  { 'battle 1 1',  'ws', 'Frostbite',       't', 'Frostbite' },
+  -- Reverberation
+  { 'battle 1 2',  'ws', 'Shockwave',       't', 'Shockwave' },
+  -- Scission
+  { 'battle 1 3',  'ws', 'Hard Slash',      't', 'Hard' },
+  { 'battle 1 3',  'ws', 'Crescent Moon',   't', 'Crescent' },
+  -- Transfixion
+  { 'battle 1 4',  'ws', 'Power Slash',     't', 'Power' },
+  -- Induration / Detonation
+  { 'battle 1 5',  'ws', 'Freezebite',      't', 'Freezebite' },
+  -- Scission / Impaction
+  { 'battle 1 6',  'ws', 'Sickle Moon',     't', 'Sickle' },
+  -- Induration / Impaction / Detonation
+  { 'battle 1 7',  'ws', 'Herculean Slash', 't', 'Herculean' },
+  -- Fragmentation
+  { 'battle 1 8',  'ws', 'Spinning Slash',  't', 'Spinning' }, -- run drk pld war
+  -- Fragmentation / Scission
+  { 'battle 1 9',  'ws', 'Resolution',      't', 'Resolutn' }, -- merit
+  -- Detonation / Compression / Distortion
+  { 'battle 1 10', 'ws', 'Fimbulvetr',      't', 'Fimbulvetr' },
+  -- Fragmentation / Distortion
+  { 'battle 1 11', 'ws', 'Ground Strike',   't', 'Ground' },
+  -- Light / Distortion
+  { 'battle 1 12', 'ws', 'Torcleaver',      't', 'Torclvr' },     -- pld drk
+  -- Light / Fragmentation
+  { 'battle 1 1',  'ws', 'Dimidiation',     't', 'Dimidiation' }, -- run
+  -- Light / Fusion
+  { 'battle 1 2',  'ws', 'Scourge',         't', 'Scourge' },     -- war pld drk run relic
 }
 
 xivhotbar_keybinds_job['Axe'] = {
@@ -156,6 +302,38 @@ xivhotbar_keybinds_job['Axe'] = {
   { 'battle 1 12', 'ws', 'Smash Axe',     't', 'Smash' },
 }
 
+xivhotbar_keybinds_job['Axe'] = {
+  -- Detonation
+  { 'battle 1 1',  'ws', 'Gale Axe',      't', 'Gale' },
+  -- Scission
+  { 'battle 1 2',  'ws', 'Rampage',       't', 'Rampage' },
+  -- Detonation / Impaction
+  { 'battle 1 3',  'ws', 'Raging Axe',    't', 'Raging' },
+  -- Impaction / Reverberation
+  { 'battle 1 4',  'ws', 'Smash Axe',     't', 'Smash' },
+  -- Scission / Detonation
+  { 'battle 1 5',  'ws', 'Bora Axe',      't', 'Bora' }, -- war drk run bst
+  -- Scission / Impaction
+  { 'battle 1 6',  'ws', 'Avalanche Axe', 't', 'Avlnche' },
+  { 'battle 1 6',  'ws', 'Calamity',      't', 'Calamity' },  -- war bst
+  -- Liquefaction / Scission / Impaction
+  { 'battle 1 7',  'ws', 'Spinning Axe',  't', 'Spinning' },  -- war drk run bst
+  -- Fusion
+  { 'battle 1 8',  'ws', 'Mistral Axe',   't', 'Mistral' },   -- war bst
+  -- Distortion / Detonation
+  { 'battle 1 9',  'ws', 'Ruinator',      't', 'Ruinator' },  -- war drk bst rng run
+  -- Fusion / Reverberation
+  { 'battle 1 10', 'ws', 'Decimation',    't', 'Decimate' },  -- war drk bst rng run
+  -- Gravitation / Reverberation
+  { 'battle 1 11', 'ws', 'Primal Rend',   't', 'Primal' },    -- bst
+  -- Liquefaction / Impaction / Fragmentation
+  { 'battle 1 12', 'ws', 'Blitz',         't', 'Blitz' },     -- bst
+  -- Darkness / Fragmentation
+  { 'battle 1 1',  'ws', 'Cloudsplitter', 't', 'Cloudsplt' }, -- war bst
+  -- Darkness / Gravitation
+  { 'battle 1 2',  'ws', 'Onslaught',     't', 'Onslaught' }, -- bst relic
+}
+
 xivhotbar_keybinds_job['Great Axe'] = {
   -- Heavy Hit
   { 'battle 1 1',  'ws', 'Iron Tempest',     't', 'Iron' },
@@ -170,20 +348,51 @@ xivhotbar_keybinds_job['Great Axe'] = {
   { 'battle 1 3',  'ws', 'Shield Break',     't', 'Shld' },
   { 'battle 1 3',  'ws', 'Armor Break',      't', 'Armr' },
   { 'battle 1 4',  'ws', 'Weapon Break',     't', 'Wpn' },
-  { 'battle 1 5',  'ws', 'Full Break',       't', 'Full' },        -- war
+  { 'battle 1 5',  'ws', 'Full Break',       't', 'Full' },     -- war
   -- Class Specific
-  { 'battle 1 6',  'ws', "King's Justice",   't', "King" },        -- war
+  { 'battle 1 6',  'ws', "King's Justice",   't', "King" },     -- war
   -- Merit Point
-  { 'battle 1 7',  'ws', 'Upheaval',         't', 'Upheaval' },    -- war drk run
+  { 'battle 1 7',  'ws', 'Upheaval',         't', 'Upheaval' }, -- war drk run
   -- Empyrean (Abyssea only)  #9
-  { 'battle 1 9',  'ws', "Ukko's Fury",      't', "Ukko's Fury" }, -- war
+  { 'battle 1 9',  'ws', "Ukko's Fury",      't', "Ukko's" },   -- war
   -- Relic & Prime (only usable with specific weapon equips) #10
-  { 'battle 1 10', 'ws', 'Metatron Torment', 't', 'Meta' },        -- war
-  { 'battle 1 10', 'ws', 'Disaster',         't', 'Distr' },       -- war
+  { 'battle 1 10', 'ws', 'Metatron Torment', 't', 'Meta' },     -- war
+  { 'battle 1 10', 'ws', 'Disaster',         't', 'Distr' },    -- war
   -- AoE Ws #11
-  { 'battle 1 11', 'ws', 'Fell Cleave',      't', 'FellClv' },     -- war drk run
+  { 'battle 1 11', 'ws', 'Fell Cleave',      't', 'FellClv' },  -- war drk run
   -- Stun WS #12
   -- none
+}
+
+xivhotbar_keybinds_job['Great Axe'] = {
+  -- Compression
+  { 'battle 1 1',  'ws', 'Keen Edge',        't', 'Keen' },
+  -- Impaction
+  { 'battle 1 2',  'ws', 'Shield Break',     't', 'Shld' },
+  { 'battle 1 2',  'ws', 'Armor Break',      't', 'Armr' },
+  { 'battle 1 2',  'ws', 'Weapon Break',     't', 'Wpn' },
+  -- Scission
+  { 'battle 1 3',  'ws', 'Iron Tempest',     't', 'Iron' },
+  -- Induration / Reverberation
+  { 'battle 1 4',  'ws', 'Raging Rush',      't', 'Raging' }, -- war
+  -- Reverberation / Scission
+  { 'battle 1 5',  'ws', 'Sturmwind',        't', 'Sturm' },
+  -- Scission / Detonation
+  { 'battle 1 6',  'ws', 'Fell Cleave',      't', 'FellClv' },  -- war drk run
+  -- Distortion
+  { 'battle 1 7',  'ws', 'Full Break',       't', 'Full' },     -- war
+  -- Distortion / Detonation
+  { 'battle 1 8',  'ws', 'Steel Cyclone',    't', 'Steel' },    -- war drk run
+  -- Fragmentation / Scission
+  { 'battle 1 9',  'ws', "King's Justice",   't', "King" },     -- war
+  -- Fusion / Compression
+  { 'battle 1 10', 'ws', 'Upheaval',         't', 'Upheaval' }, -- war drk run
+  -- Transfixion / Scission / Gravitation
+  { 'battle 1 11', 'ws', 'Disaster',         't', 'Distr' },    -- war
+  -- Light / Fragmentation
+  { 'battle 1 12', 'ws', "Ukko's Fury",      't', "Ukko's" },   -- war
+  -- Light / Fusion
+  { 'battle 1 1',  'ws', 'Metatron Torment', 't', 'Meta' },     -- war
 }
 
 xivhotbar_keybinds_job['Scythe'] = {
@@ -215,6 +424,39 @@ xivhotbar_keybinds_job['Scythe'] = {
   -- none
 }
 
+xivhotbar_keybinds_job['Scythe'] = {
+  -- Induration
+  { 'battle 1 1',  'ws', 'Guillotine',       't', 'Guill' }, -- drk
+  -- Reverberation
+  { 'battle 1 2',  'ws', 'Dark Harvest',     't', 'DHvst' },
+  -- Scission
+  { 'battle 1 3',  'ws', 'Slice',            't', 'Slice' },
+  -- Compression / Reverberation
+  { 'battle 1 4',  'ws', 'Infernal Scythe',  't', 'Infernal' }, -- war drk
+  -- Compression / Scission
+  { 'battle 1 5',  'ws', 'Nightmare Scythe', 't', 'Nmare' },
+  -- Induration / Reverberation
+  { 'battle 1 6',  'ws', 'Shadow of Death',  't', 'Shadow' }, -- war drk
+  -- Reverberation / Scission
+  { 'battle 1 7',  'ws', 'Spinning Scythe',  't', 'Spinning' },
+  -- Transfixion / Scission
+  { 'battle 1 8',  'ws', 'Vorpal Scythe',    't', 'Vorpal' },
+  -- Distortion
+  { 'battle 1 9',  'ws', 'Cross Reaper',     't', 'Cross' },
+  -- Distortion / Scission
+  { 'battle 1 10', 'ws', 'Spiral Hell',      't', 'Spiral' },  -- war drk bst
+  -- Fusion / Compression
+  { 'battle 1 11', 'ws', 'Insurgency',       't', 'Insurge' }, -- drk
+  -- Gravitation / Reverberation
+  { 'battle 1 12', 'ws', 'Entropy',          't', 'Entropy' }, -- war drk bst
+  -- Induration / Reverberation / Fusion
+  { 'battle 1 1',  'ws', 'Origin',           't', 'Origin' },  -- drk
+  -- Darkness / Distortion
+  { 'battle 1 2',  'ws', 'Quietus',          't', 'Quietus' },
+  -- Darkness / Gravitation
+  { 'battle 1 3',  'ws', 'Catastrophe',      't', 'Cata' }, -- drk relic
+}
+
 xivhotbar_keybinds_job['Polearm'] = {
   -- Heavy Hit
   { 'battle 1 1',  'ws',                'Vorpal Thrust',   't', 'Vorpal' },
@@ -237,9 +479,40 @@ xivhotbar_keybinds_job['Polearm'] = {
   { 'battle 1 10', 'ws',                'Geirskogul',      't', 'Geirsk' },  -- drg
   { 'battle 1 10', 'ws',                'Diarmuid',        't', 'Diarm' },
   -- AoE Ws #11
-  { 'battle 1 11', 'ws',                'Sonic Thrust',    't', 'Sonic' }, -- war pld drg
+  { 'battle 1 11', 'Sonic Thrust',      'name',            't', 'Sonic' }, -- war pld drg
   -- Stun WS #12
   { 'battle 1 12', 'ws',                'Leg Sweep',       't', 'LegSwp' },
+}
+
+xivhotbar_keybinds_job['Polearm'] = {
+  -- Compression
+  { 'battle 1 1',  'ws', 'Penta Thrust',      't', 'Penta' },
+  -- Impaction
+  { 'battle 1 2',  'ws', 'Leg Sweep',         't', 'LegSwp' },
+  -- Transfixion
+  { 'battle 1 3',  'ws', 'Double Thrust',     't', 'Double' },
+  -- Reverberation / Transfixion
+  { 'battle 1 4',  'ws', 'Vorpal Thrust',     't', 'Vorpal' },
+  -- Transfixion / Impaction
+  { 'battle 1 5',  'ws', 'Thunder Thrust',    't', 'Thunder' },
+  { 'battle 1 5',  'ws', 'Raiden Thrust',     't', 'Raiden' }, -- war pld drg
+  { 'battle 1 5',  'ws', 'Skewer',            't', 'Skewer' }, -- drg
+  -- Transfixion / Scission
+  { 'battle 1 6',  'ws', 'Sonic Thrust',      't', 'Sonic' },  -- war pld drg
+  -- Fusion
+  { 'battle 1 7',  'ws', 'Wheeling Thrust',   't', 'Wheel' },  -- drg
+  -- Fusion / Transfixion
+  { 'battle 1 8',  'ws', 'Drakesbane',        't', 'Drakes' },
+  -- Gravitation / Induration
+  { 'battle 1 9',  'ws', 'Impulse Drive',     't', 'Impulse' }, -- war sam drg
+  -- Gravitation / Transfixion
+  { 'battle 1 10', 'ws', 'Stardiver',         't', 'Star' },    -- war sam drg
+  -- Transfixion / Scission / Gravitation
+  { 'battle 1 11', 'ws', 'Diarmuid',          't', 'Diarm' },
+  -- Light / Distortion
+  { 'battle 1 12', 'ws', 'Geirskogul',        't', 'Geirsk' },  -- drg
+  -- Light / Fragmentation
+  { 'battle 1 1',  'ws', "Camlann's Torment", 't', 'Camlann' }, -- drg
 }
 
 xivhotbar_keybinds_job['Katana'] = {
@@ -252,23 +525,57 @@ xivhotbar_keybinds_job['Katana'] = {
   -- Multi-Hit
   { 'battle 1 2',  'ws', 'Blade: Retsu', 't', 'Retsu' },
   { 'battle 1 2',  'ws', 'Blade: Chi',   't', 'Chi' },
-  { 'battle 1 2',  'ws', 'Blade: Jin',   't', 'Jin' },  -- nin
-  { 'battle 1 2',  'ws', 'Blade: Ku',    't', 'Ku' },   -- nin
+  { 'battle 1 2',  'ws', 'Blade: Jin',   't', 'Jin' },   -- nin
+  { 'battle 1 2',  'ws', 'Blade: Ku',    't', 'Ku' },    -- nin
   -- Specials
-  { 'battle 1 3',  'ws', 'Blade: Yu',    't', 'Yu' },   -- nin
-  -- Class Specific
-  { 'battle 1 7',  'ws', 'Blade: Kamu',  't', 'Kamu' }, -- nin
-  -- Merit Point
+  { 'battle 1 3',  'ws', 'Blade: Yu',    't', 'Yu' },    -- nin
+  -- Prime #6
+  { 'battle 1 6',  'ws', 'Zesho Meppo',  't', 'Zesho' }, -- nin
+  -- Class Specific #7
+  { 'battle 1 7',  'ws', 'Blade: Kamu',  't', 'Kamu' },  -- nin
+  -- Merit Point #8
   { 'battle 1 8',  'ws', 'Blade: Shun',  't', 'Shun' },
   -- Empyrean (Abyssea only)  #9
   { 'battle 1 9',  'ws', 'Blade: Hi',    't', 'Hi' },    -- nin
-  -- Relic & Prime (only usable with specific weapon equips) #10
+  -- Relic (only usable with specific weapon equips) #10
   { 'battle 1 10', 'ws', 'Blade: Metsu', 't', 'Metsu' }, -- nin relic
-  { 'battle 1 10', 'ws', 'Zesho Meppo',  't', 'Zesho' }, -- nin
   -- AoE Ws #11
   -- none
   -- Stun WS #12
   -- none
+}
+
+xivhotbar_keybinds_job['Katana'] = {
+  -- Compression
+  { 'battle 1 1',  'ws', 'Blade: Ei',    't', 'Ei' },
+  -- Reverberation
+  { 'battle 1 2',  'ws', 'Blade: Teki',  't', 'Teki' },
+  -- Scission
+  { 'battle 1 3',  'ws', 'Blade: Retsu', 't', 'Retsu' },
+  -- Transfixion
+  { 'battle 1 4',  'ws', 'Blade: Rin',   't', 'Rin' },
+  -- Impaction / Detonation
+  { 'battle 1 5',  'ws', 'Blade: Jin',   't', 'Jin' }, -- nin
+  -- Impaction / Transfixion
+  { 'battle 1 6',  'ws', 'Blade: Chi',   't', 'Chi' },
+  -- Induration / Detonation
+  { 'battle 1 7',  'ws', 'Blade: To',    't', 'To' },
+  -- Reverberation / Scission
+  { 'battle 1 8',  'ws', 'Blade: Yu',    't', 'Yu' },   -- nin
+  -- Gravitation
+  { 'battle 1 9',  'ws', 'Blade: Ten',   't', 'Ten' },  -- nin
+  -- Fragmentation / Compression
+  { 'battle 1 10', 'ws', 'Blade: Kamu',  't', 'Kamu' }, -- nin
+  -- Fusion / Impaction
+  { 'battle 1 11', 'ws', 'Blade: Shun',  't', 'Shun' },
+  -- Gravitation / Transfixion
+  { 'battle 1 12', 'ws', 'Blade: Ku',    't', 'Ku' },    -- nin
+  -- Induration / Reverberation / Fusion
+  { 'battle 1 1',  'ws', 'Zesho Meppo',  't', 'Zesho' }, -- nin
+  -- Darkness / Fragmentation
+  { 'battle 1 2',  'ws', 'Blade: Metsu', 't', 'Metsu' }, -- nin relic
+  -- Darkness / Gravitation
+  { 'battle 1 3',  'ws', 'Blade: Hi',    't', 'Hi' },    -- nin
 }
 
 xivhotbar_keybinds_job['Great Katana'] = {
@@ -286,48 +593,113 @@ xivhotbar_keybinds_job['Great Katana'] = {
   { 'battle 1 4',  'ws', 'Tachi: Yukikaze', 't', 'Yuki' },  -- sam
   { 'battle 1 5',  'ws', 'Tachi: Gekko',    't', 'Gekko' }, -- sam
   { 'battle 1 6',  'ws', 'Tachi: Kasha',    't', 'Kasha' }, -- sam
-  -- Merit Point
+  -- Prime #6
+  { 'battle 1 7',  'ws', 'Tachi: Mumei',    't', 'Mumei' }, -- sam
+  -- Merit Point #8
   { 'battle 1 8',  'ws', 'Tachi: Shoha',    't', 'Shoha' }, -- sam
   -- Empyrean (Abyssea only)  #9
   { 'battle 1 9',  'ws', 'Tachi: Fudo',     't', 'Fudo' },  -- sam
-  -- Relic & Prime (only usable with specific weapon equips) #10
+  -- Relic (only usable with specific weapon equips) #10
   { 'battle 1 10', 'ws', 'Tachi: Kaiten',   't', 'Kaiten' },
-  { 'battle 1 10', 'ws', 'Tachi: Mumei',    't', 'Mumei' }, -- sam
   -- AoE Ws #11
   -- none
   -- Stun WS #12
   { 'battle 1 12', 'ws', 'Tachi: Hobaku',   't', 'Hobaku' },
 }
 
+xivhotbar_keybinds_job['Great Katana'] = {
+  -- Induration
+  { 'battle 1 1',  'ws', 'Tachi: Hobaku',   't', 'Hobaku' },
+  -- Liquefaction
+  { 'battle 1 2',  'ws', 'Tachi: Kagero',   't', 'Kagero' },
+  -- Compression / Scission
+  { 'battle 1 3',  'ws', 'Tachi: Ageha',    't', 'Ageha' },
+  -- Induration / Detonation
+  { 'battle 1 4',  'ws', 'Tachi: Yukikaze', 't', 'Yuki' }, -- sam
+  -- Reverberation / Impaction
+  { 'battle 1 5',  'ws', 'Tachi: Koki',     't', 'Koki' },
+  -- Scission / Detonation
+  { 'battle 1 6',  'ws', 'Tachi: Jinpu',    't', 'Jinpu' },
+  -- Transfixion / Impaction
+  { 'battle 1 7',  'ws', 'Tachi: Goten',    't', 'Goten' },
+  -- Transfixion / Scission
+  { 'battle 1 8',  'ws', 'Tachi: Enpi',     't', 'Enpi' },
+  -- Distortion / Reverberation
+  { 'battle 1 9',  'ws', 'Tachi: Gekko',    't', 'Gekko' }, -- sam
+  -- Fragmentation / Compression
+  { 'battle 1 10', 'ws', 'Tachi: Shoha',    't', 'Shoha' }, -- sam
+  -- Fusion / Compression
+  { 'battle 1 11', 'ws', 'Tachi: Kasha',    't', 'Kasha' }, -- sam
+  -- Gravitation / Induration
+  { 'battle 1 12', 'ws', 'Tachi: Rana',     't', 'Rana' },  -- sam
+  -- Detonation / Compression / Distortion
+  { 'battle 1 1',  'ws', 'Tachi: Mumei',    't', 'Mumei' }, -- sam
+  -- Light / Distortion
+  { 'battle 1 2',  'ws', 'Tachi: Fudo',     't', 'Fudo' },  -- sam
+  -- Light / Fragmentation
+  { 'battle 1 3',  'ws', 'Tachi: Kaiten',   't', 'Kaiten' },
+}
+
 xivhotbar_keybinds_job['Club'] = {
   -- Heavy Hit
-  { 'battle 1 1',  'ws', 'True Strike',    't',  'True' },
-  { 'battle 1 1',  'ws', 'Judgment',       't',  'Judgment' }, -- war whm pld drk sam blu geo
+  { 'battle 1 1',  'ws', 'True Strike',    't', 'True' },
+  { 'battle 1 1',  'ws', 'Judgment',       't', 'Judgment' }, -- war whm pld drk sam blu geo
   -- Multi-Hit
-  { 'battle 1 2',  'ws', 'Hexa Strike',    't',  'Hexa' },     -- whm geo
-  { 'battle 1 2',  'ws', 'Black Halo',     't',  'Bl Halo' },  -- war mnk whm blm pld smn blu sch geo
+  { 'battle 1 2',  'ws', 'Hexa Strike',    't', 'Hexa' },     -- whm geo
+  { 'battle 1 2',  'ws', 'Black Halo',     't', 'Bl Halo' },  -- war mnk whm blm pld smn blu sch geo
   -- Light
-  { 'battle 1 3',  'ws', 'Shining Strike', 't',  'Shining' },
-  { 'battle 1 3',  'ws', 'Seraph Strike',  't',  'Seraph' },  -- war whm pld drk sam blu geo
-  { 'battle 1 3',  'ws', 'Flash Nova',     't',  'Fl Nova' }, -- war whm pld drk sam blu geo
+  { 'battle 1 3',  'ws', 'Shining Strike', 't', 'Shining' },
+  { 'battle 1 3',  'ws', 'Seraph Strike',  't', 'Seraph' },  -- war whm pld drk sam blu geo
+  { 'battle 1 3',  'ws', 'Flash Nova',     't', 'Fl Nova' }, -- war whm pld drk sam blu geo
   -- Specials
-  { 'battle 1 4',  'ws', 'Skullbreaker',   't',  'Skullbrk' },
-  { 'battle 1 5',  'ws', 'Starlight',      'me', 'Star' },
-  { 'battle 1 5',  'ws', 'Moonlight',      'me', 'Moon' },     -- war whm pld drk sam blu geo
+  { 'battle 1 4',  'ws', 'Skullbreaker',   't', 'Skullbrk' },
+  { 'battle 1 5',  'ws', 'Starlight',      't', 'Star' },
+  { 'battle 1 5',  'ws', 'Moonlight',      't', 'Moon' },     -- war whm pld drk sam blu geo
   -- Class Specific
-  { 'battle 1 6',  'ws', 'Mystic Boon',    't',  'Mystic' },   -- whm only
-  { 'battle 1 6',  'ws', 'Exudation',      't',  'Exuda' },    -- geo
+  { 'battle 1 6',  'ws', 'Mystic Boon',    't', 'Mystic' },   -- whm only
+  { 'battle 1 6',  'ws', 'Exudation',      't', 'Exuda' },    -- geo
   -- Merit Point
-  { 'battle 1 7',  'ws', 'Realmrazer',     't',  'Realmrzr' }, -- war mnk whm blm pld smn blu sch geo
+  { 'battle 1 7',  'ws', 'Realmrazer',     't', 'Realmrzr' }, -- war mnk whm blm pld smn blu sch geo
   -- Empyrean (Abyssea only)  #9
-  { 'battle 1 9',  'ws', 'Dagan',          't',  'Dagan' },    -- whm
+  { 'battle 1 9',  'ws', 'Dagan',          't', 'Dagan' },    -- whm
   -- Relic & Prime (only usable with specific weapon equips) #10
-  { 'battle 1 10', 'ws', 'Randgrith',      't',  'Randgrt' },  -- whm sch geo relic
-  { 'battle 1 10', 'ws', 'Dagda',          't',  'Dagda' },    -- whm geo recc
+  { 'battle 1 10', 'ws', 'Randgrith',      't', 'Randgrt' },  -- whm sch geo relic
+  { 'battle 1 10', 'ws', 'Dagda',          't', 'Dagda' },    -- whm geo recc
   -- AoE Ws #11
   -- none
   -- Stun WS #12
-  { 'battle 1 12', 'ws', 'Brainshaker',    't',  'Brainshkr' },
+  { 'battle 1 12', 'ws', 'Brainshaker',    't', 'Brainshkr' },
+}
+
+xivhotbar_keybinds_job['Club'] = {
+  -- No Skillchain
+  { 'battle 1 1',  'ws', 'Starlight',      't', 'Star' },
+  { 'battle 1 1',  'ws', 'Moonlight',      't', 'Moon' },     -- war whm pld drk sam blu geo
+  { 'battle 1 1',  'ws', 'Mystic Boon',    't', 'Mystic' },   -- whm only
+  { 'battle 1 1',  'ws', 'Dagan',          't', 'Dagan' },    -- whm
+  -- Impaction
+  { 'battle 1 2',  'ws', 'Judgment',       't', 'Judgment' }, -- war whm pld drk sam blu geo
+  { 'battle 1 2',  'ws', 'Shining Strike', 't', 'Shining' },
+  { 'battle 1 2',  'ws', 'Seraph Strike',  't', 'Seraph' },   -- war whm pld drk sam blu geo
+  -- Reverberation
+  { 'battle 1 3',  'ws', 'Brainshaker',    't', 'Brainshkr' },
+  -- Detonation / Impaction
+  { 'battle 1 4',  'ws', 'True Strike',    't', 'True' },
+  -- Induration / Reverberation
+  { 'battle 1 5',  'ws', 'Flash Nova',     't', 'Fl Nova' }, -- war whm pld drk sam blu geo
+  { 'battle 1 5',  'ws', 'Skullbreaker',   't', 'Skullbrk' },
+  -- Fusion
+  { 'battle 1 6',  'ws', 'Hexa Strike',    't', 'Hexa' },     -- whm geo
+  -- Fragmentation / Compression
+  { 'battle 1 7',  'ws', 'Black Halo',     't', 'Bl Halo' },  -- war mnk whm blm pld smn blu sch geo
+  -- Fusion / Impaction
+  { 'battle 1 8',  'ws', 'Realmrazer',     't', 'Realmrzr' }, -- war mnk whm blm pld smn blu sch geo
+  -- Transfixion / Scission / Gravitation
+  { 'battle 1 9',  'ws', 'Dagda',          't', 'Dagda' },    -- whm geo recc
+  -- Darkness / Fragmentation
+  { 'battle 1 10', 'ws', 'Exudation',      't', 'Exuda' },    -- geo
+  -- Light / Fragmentation
+  { 'battle 1 11', 'ws', 'Randgrith',      't', 'Randgrt' },  -- whm sch geo relic
 }
 
 xivhotbar_keybinds_job['Staff'] = {
@@ -362,6 +734,39 @@ xivhotbar_keybinds_job['Staff'] = {
   -- none
 }
 
+xivhotbar_keybinds_job['Staff'] = {
+  -- No Skillchain
+  { 'battle 1 1',  'ws', 'Spirit Taker',     't', 'Spirit' },
+  { 'battle 1 1',  'ws', 'Myrkr',            't', 'Myrkr' }, -- blm smn sch
+  -- Detonation
+  { 'battle 1 2',  'ws', 'Shell Crusher',    't', 'Shell' },
+  -- Impaction
+  { 'battle 1 3',  'ws', 'Heavy Swing',      't', 'Heavy' },
+  { 'battle 1 3',  'ws', 'Rock Crusher',     't', 'Rock' },
+  -- Compression / Reverberation
+  { 'battle 1 4',  'ws', 'Starburst',        't', 'Starbrst' },
+  { 'battle 1 4',  'ws', 'Sunburst',         't', 'Sunbrst' },  -- war mnk whm pld geo
+  { 'battle 1 4',  'ws', 'Cataclysm',        't', 'Catcylsm' }, -- war mnk whm pld geo
+  -- Detonation / Impaction
+  { 'battle 1 5',  'ws', 'Earth Crusher',    't', 'Crusher' },  -- war mnk whm pld geo
+  -- Liquefaction / Impaction
+  { 'battle 1 6',  'ws', 'Full Swing',       't', 'Full' },
+  -- Fusion / Reverberation
+  { 'battle 1 7',  'ws', 'Garland of Bliss', 't', 'Garland' }, -- smn
+  -- Gravitation / Induration
+  { 'battle 1 8',  'ws', 'Shattersoul',      't', 'Shatter' },
+  -- Gravitation / Reverberation
+  { 'battle 1 9',  'ws', 'Retribution',      't', 'Retrb' },  -- war mnk whm blm pld brd drg smn sch geo
+  -- Gravitation / Transfixion
+  { 'battle 1 10', 'ws', 'Omniscience',      't', 'Omnisc' }, -- sch
+  -- Induration / Reverberation / Fusion
+  { 'battle 1 11', 'ws', 'Oshala',           't', 'Oshala' }, -- blm smn sch
+  -- Fragmentation / Distortion
+  { 'battle 1 12', 'ws', 'Vidohunir',        't', 'Vidoh' },  -- blm
+  -- Darkness / Distortion
+  { 'battle 1 1',  'ws', 'Gate of Tartarus', 't', 'Gate' },   -- blm smn relic
+}
+
 xivhotbar_keybinds_job['Bow'] = {
   -- Heavy Hit
   { 'battle 1 1',  'ws', 'Flaming Arrow',     't', 'Flame' },    -- rng sub
@@ -374,17 +779,43 @@ xivhotbar_keybinds_job['Bow'] = {
   -- Specials
   { 'battle 1 4',  'ws', 'Dulling Arrow',     't', 'Dull' },     -- rng sub
   { 'battle 1 4',  'ws', 'Blast Arrow',       't', 'Blast' },    -- rng
-  -- Merit Point
+  -- Prime #6
+  { 'battle 1 6',  'ws', 'Sarv',              't', 'Sarv' },     -- rng
+  -- Merit Point #8
   { 'battle 1 8',  'ws', 'Apex Arrow',        't', 'Apex' },     -- rng sam
   -- Empyrean (Abyssea only)  #9
   { 'battle 1 9',  'ws', "Jishnu's Radiance", 't', 'Jishnu' },   -- rng
-  -- Relic & Prime (only usable with specific weapon equips) #10
+  -- Relic (only usable with specific weapon equips) #10
   { 'battle 1 10', 'ws', 'Namas Arrow',       't', 'Namas' },    -- rng sam relic
-  { 'battle 1 10', 'ws', 'Sarv',              't', 'Sarv' },     -- rng
   -- AoE Ws #11
   -- none
   -- Stun WS #12
   -- none
+}
+
+xivhotbar_keybinds_job['Bow'] = {
+  -- Induration / Transfixion
+  { 'battle 1 1',  'ws', 'Blast Arrow',       't', 'Blast' },    -- rng
+  -- Liquefaction / Transfixion
+  { 'battle 1 2',  'ws', 'Flaming Arrow',     't', 'Flame' },    -- rng sub
+  { 'battle 1 2',  'ws', 'Dulling Arrow',     't', 'Dull' },     -- rng sub
+  -- Reverberation / Transfixion
+  { 'battle 1 3',  'ws', 'Piercing Arrow',    't', 'Pierce' },   -- rng sub
+  { 'battle 1 3',  'ws', 'Refulgent Arrow',   't', 'Reflgnt' },  -- rng sub
+  -- Reverberation / Transfixion / Detonation
+  { 'battle 1 4',  'ws', 'Sidewinder',        't', 'Sidewndr' }, -- rng sub
+  -- Fusion
+  { 'battle 1 5',  'ws', 'Arching Arrow',     't', 'Arch' },     -- rng
+  -- Fragmentation / Transfixion
+  { 'battle 1 6',  'ws', 'Apex Arrow',        't', 'Apex' },     -- rng sam
+  -- Fusion / Transfixion
+  { 'battle 1 7',  'ws', 'Empyreal Arrow',    't', 'Empyrl' },   -- rng
+  -- Transfixion / Scission / Gravitation
+  { 'battle 1 8',  'ws', 'Sarv',              't', 'Sarv' },     -- rng
+  -- Light / Distortion
+  { 'battle 1 9',  'ws', 'Namas Arrow',       't', 'Namas' },    -- rng sam relic
+  -- Light / Fusion
+  { 'battle 1 10', 'ws', "Jishnu's Radiance", 't', 'Jishnu' },   -- rng
 }
 
 xivhotbar_keybinds_job['Marksmanship'] = {
@@ -398,19 +829,50 @@ xivhotbar_keybinds_job['Marksmanship'] = {
   -- Specials
   { 'battle 1 4',  'ws', 'Split Shot',    't', 'Split' },    -- rng cor
   { 'battle 1 4',  'ws', 'Numbing Shot',  't', 'Numb' },     -- rng cor sub
-  -- Class Specific
+  -- Prime #6
+  { 'battle 1 6',  'ws', 'Terminus',      't', 'Terminus' }, -- rng cor
+  -- Class Specific #7
   { 'battle 1 7',  'ws', 'Heavy Shot',    't', 'Heavy' },    -- rng
   { 'battle 1 7',  'ws', 'Trueflight',    't', 'Trueflt' },  -- rng
   { 'battle 1 7',  'ws', 'Leaden Salute', 't', 'Leaden' },   -- cor
-  -- Merit Point
+  -- Merit Point #8
   { 'battle 1 8',  'ws', 'Last Stand',    't', 'Last' },     -- thf rng cor
   -- Empyrean (Abyssea only)  #9
   { 'battle 1 9',  'ws', 'Wildfire',      't', 'Wildfire' }, -- rng cor
-  -- Relic & Prime (only usable with specific weapon equips) #10
+  -- Relic (only usable with specific weapon equips) #10
   { 'battle 1 10', 'ws', 'Coronach',      't', 'Coronach' }, -- rng cor relic
-  { 'battle 1 10', 'ws', 'Terminus',      't', 'Terminus' }, -- rng cor
   -- AoE Ws #11
   -- none
   -- Stun WS #12
   -- none
+}
+
+xivhotbar_keybinds_job['Marksmanship'] = {
+  -- Induration / Transfixion
+  { 'battle 1 1',  'ws', 'Blast Shot',    't', 'Blast' },    -- rng
+  -- Liquefaction / Transfixion
+  { 'battle 1 2',  'ws', 'Sniper Shot',   't', 'Sniper' },   -- rng cor sub
+  -- Reverberation / Transfixion
+  { 'battle 1 3',  'ws', 'Hot Shot',      't', 'Hot' },      -- rng cor sub
+  { 'battle 1 3',  'ws', 'Split Shot',    't', 'Split' },    -- rng cor
+  -- Induration / Impaction / Detonation
+  { 'battle 1 4',  'ws', 'Numbing Shot',  't', 'Numb' },     -- rng cor sub
+  -- Reverberation / Transfixion / Detonation
+  { 'battle 1 5',  'ws', 'Slug Shot',     't', 'Slug' },     -- rng cor sub
+  -- Fusion
+  { 'battle 1 6',  'ws', 'Heavy Shot',    't', 'Heavy' },    -- rng
+  -- Fragmentation / Scission
+  { 'battle 1 7',  'ws', 'Trueflight',    't', 'Trueflt' },  -- rng
+  -- Fusion / Reverberation
+  { 'battle 1 8',  'ws', 'Last Stand',    't', 'Last' },     -- thf rng cor
+  -- Fusion / Transfixion
+  { 'battle 1 9',  'ws', 'Detonator',     't', 'Detonate' }, -- rng cor
+  -- Gravitation / Transfixion
+  { 'battle 1 10', 'ws', 'Leaden Salute', 't', 'Leaden' },   -- cor
+  -- Induration / Reverberation / Fusion
+  { 'battle 1 11', 'ws', 'Terminus',      't', 'Terminus' }, -- rng cor
+  -- Darkness / Fragmentation
+  { 'battle 1 12', 'ws', 'Coronach',      't', 'Coronach' }, -- rng cor relic
+  -- Darkness / Gravitation
+  { 'battle 1 1',  'ws', 'Wildfire',      't', 'Wildfire' }, -- rng cor
 }

--- a/data/Examples/whm.lua
+++ b/data/Examples/whm.lua
@@ -61,13 +61,13 @@ xivhotbar_keybinds_job['Base'] = {
 
   -- Hotbar #3 (CTRL 1-12)
   --------------------------------------------------------------------------------------
-  { 'battle 3 1',  'ma', 'Dia',             't',     'Dia' },
-  { 'battle 3 1',  'ma', 'Dia II',          't',     'Dia2' },
+  { 'battle 3 1',  'ma', 'Dia',             'stnpc', 'Dia' },
+  { 'battle 3 1',  'ma', 'Dia II',          'stnpc', 'Dia2' },
   --------------------------------------------------------------------------------------
-  { 'battle 3 2',  'ma', 'Paralyze',        't',     'Paralyze' },
-  { 'battle 3 3',  'ma', 'Slow',            't',     'Slow' },
+  { 'battle 3 2',  'ma', 'Paralyze',        'stnpc', 'Paralyze' },
+  { 'battle 3 3',  'ma', 'Slow',            'stnpc', 'Slow' },
   { 'battle 3 4',  'ma', 'Silence',         'stnpc', 'Silence' },
-  { 'battle 3 5',  'ma', 'Addle',           't',     'Addle' },
+  { 'battle 3 5',  'ma', 'Addle',           'stnpc', 'Addle' },
 
   { 'battle 3 12', 'ja', 'Asylum',          'me',    'Asylum' },
 
@@ -107,11 +107,11 @@ xivhotbar_keybinds_job['Base'] = {
   { 'battle 5 4',  'ma', 'Barfira',         'me',    'Fira',      'Barfira' },
   { 'battle 5 5',  'ma', 'Barblizzara',     'me',    'Blizzara',  'Barblizzara' },
   { 'battle 5 6',  'ma', 'Barthundra',      'me',    'Thundra',   'Barthundra' },
-  { 'battle 5 7',  'ma', 'Banish',          't',     'Banish' },
-  { 'battle 5 7',  'ma', 'Banish II',       't',     'Banish2' },
-  { 'battle 5 7',  'ma', 'Banish III',      't',     'Banish3' },
-  { 'battle 5 8',  'ma', 'Holy',            't',     'Holy' },
-  { 'battle 5 8',  'ma', 'Holy II',         't',     'Holy2' },
+  { 'battle 5 7',  'ma', 'Banish',          'stnpc', 'Banish' },
+  { 'battle 5 7',  'ma', 'Banish II',       'stnpc', 'Banish2' },
+  { 'battle 5 7',  'ma', 'Banish III',      'stnpc', 'Banish3' },
+  { 'battle 5 8',  'ma', 'Holy',            'stnpc', 'Holy' },
+  { 'battle 5 8',  'ma', 'Holy II',         'stnpc', 'Holy2' },
 
   { 'battle 5 10', 'ma', 'Boost-VIT',       'me',    'VIT++' },
   { 'battle 5 11', 'ma', 'Boost-MND',       'me',    'MND++' },
@@ -144,7 +144,7 @@ xivhotbar_keybinds_job['NIN'] = {
 
 xivhotbar_keybinds_job['BLM'] = {
   -- Hotbar #3 (CTRL 1-0)
-  { 'battle 3 6',  'ma', 'Blind',    't',     'Blind' },
+  { 'battle 3 6',  'ma', 'Blind',    'stnpc', 'Blind' },
   { 'battle 3 7',  'ma', 'Bind',     'stnpc', 'Bind' },
   { 'battle 3 8',  'ma', 'Sleep',    'stnpc', 'Sleep' },
   { 'battle 3 9',  'ma', 'Sleep II', 'stnpc', 'Sleep2' },
@@ -154,12 +154,12 @@ xivhotbar_keybinds_job['BLM'] = {
 
 xivhotbar_keybinds_job['RDM'] = {
   -- Hotbar #3 (CTRL 1-0)
-  { 'battle 3 6',  'ma', 'Blind',   't',     'Blind' },
+  { 'battle 3 6',  'ma', 'Blind',   'stnpc', 'Blind' },
   { 'battle 3 7',  'ma', 'Bind',    'stnpc', 'Bind' },
   { 'battle 3 8',  'ma', 'Sleep',   'stnpc', 'Sleep' },
   { 'battle 3 9',  'ma', 'Gravity', 'stnpc', 'Gravity' },
   { 'battle 3 10', 'ma', 'Refresh', 'stnpc', 'Refresh' },
-  { 'battle 3 11', 'ma', 'Dispel',  't',     'Dispel' },
+  { 'battle 3 11', 'ma', 'Dispel',  'stnpc', 'Dispel' },
 }
 
 xivhotbar_keybinds_job['SCH'] = {

--- a/lib/skillchains.lua
+++ b/lib/skillchains.lua
@@ -113,6 +113,12 @@ function skillchains:initialize()
   self.is_initialized = true
 end
 
+function skillchains:destroy()
+  self.is_initialized = false
+  self.sc_properties = {}
+  self.target_buffs = {}
+end
+
 ----------------------------------------------------------------------
 -- Handles any incoming action packets that might form or update skillchains.
 -- Logic:
@@ -424,12 +430,14 @@ end)
 -- This runs every frame (~30 FPS). We only do a cleanup check every 30 mins.
 ----------------------------------------------------------------------
 windower.register_event('prerender', function()
-  local now = os.time()
-  local THIRTY_MINUTES = 30 * 60
+  if skillchains.is_initialized then
+    local now = os.time()
+    local THIRTY_MINUTES = 30 * 60
 
-  if (now - skillchains.last_cleanup_check) >= THIRTY_MINUTES then
-    skillchains:cleanup_old_data()
-    skillchains.last_cleanup_check = now
+    if (now - skillchains.last_cleanup_check) >= THIRTY_MINUTES then
+      skillchains:cleanup_old_data()
+      skillchains.last_cleanup_check = now
+    end
   end
 end)
 

--- a/lib/ui.lua
+++ b/lib/ui.lua
@@ -1048,6 +1048,44 @@ function ui:setup(theme_options)
   self.is_setup = true
 end
 
+function ui:destroy()
+  database:destroy()
+
+  self.hotbar = {
+    initialized = false,
+    ready = false,
+    hide_hotbars = false,
+    in_battle = false
+  }
+
+  self.hover_icon = {
+    row = nil,
+    col = nil,
+    prev_row = nil,
+    prev_col = nil
+  }
+
+  self.player = {}
+  self.recasts = {}
+  self.feedback_icon = nil
+  self.hotbars = {}
+  self.theme = {}
+  self.feedback = {}
+  self.feedback.is_active = false
+  self.feedback.current_opacity = 0
+  self.feedback.max_opacity = 0
+  self.feedback.speed = 0
+  self.disabled_slots = {}
+  self.disabled_slots.actions = {}
+  self.disabled_slots.no_vitals = {}
+  self.disabled_slots.on_cooldown = {}
+  self.outlined_slots = {}
+  self.is_setup = false
+  self.disabled_icons = {}
+  self.current_tick = 0
+  self.current_target = nil
+end
+
 function ui:swap_icons(swap_table)
   local source_row     = swap_table.source.row
   local source_slot    = swap_table.source.slot

--- a/priv_res/database.lua
+++ b/priv_res/database.lua
@@ -79,6 +79,13 @@ function database:import()
   return true
 end
 
+function database:destroy()
+  self.ma     = {}
+  self.ja     = {}
+  self.ws     = {}
+  self.bstpet = {}
+end
+
 --[[
 
     Map weapon skills

--- a/xivhotbar2.lua
+++ b/xivhotbar2.lua
@@ -54,13 +54,14 @@ require('luau')
 
 -- User settings --
 local defaults = require('defaults')
-local settings = config.load(defaults)
-config.save(settings)
-first_0x050 = false
 
 -- Load theme options according to settings --
-local theme = require('theme')
-local theme_options = theme.apply(settings)
+local settings
+local theme
+local theme_options
+
+first_0x050 = false
+
 
 
 -- Addon Dependencies --
@@ -71,14 +72,14 @@ local keyboard = require('lib/keyboard_mapper')
 local box = require('lib/move_box')
 local player = require('lib/player')
 local ui = require('lib/ui')
-local xiv
-local current_zone = 0
+
 local state = {
   ready = false,
   demo = false,
   inventory_ready = false,
   inventory_loading = false
 }
+
 local loaded = windower.ffxi.get_info().logged_in
 local first_load_done = false
 
@@ -260,9 +261,6 @@ local function print_help()
   log("reload: Reloads the hotbar, if you have made changes to the hotbar-file, this is faster for loading.")
   log("mount: either dismounts if mounted, or mounts the indicated mount")
 end
-
-
-
 
 -- ON COMMAND --
 windower.register_event('addon command', function(command, ...)
@@ -500,6 +498,7 @@ windower.register_event('load', function()
     defaults = require('defaults')
     settings = config.load(defaults)
     config.save(settings)
+
     -- Load theme options according to settings --
     theme = require('theme')
     theme_options = theme.apply(settings)
@@ -515,9 +514,11 @@ windower.register_event('login', function()
   local windower_player = windower.ffxi.get_player()
   if windower_player ~= nil then
     windower.send_command('lua load xivhotbar2')
+
     defaults = require('defaults')
     settings = config.load(defaults)
     config.save(settings)
+
     -- Load theme options according to settings --
     theme = require('theme')
     theme_options = theme.apply(settings)
@@ -527,6 +528,40 @@ windower.register_event('login', function()
 
     initialize()
   end
+end)
+
+windower.register_event('logout', function()
+  settings = nil
+  theme = nil
+  theme_options = nil
+  state = {
+    ready = false,
+    demo = false,
+    inventory_ready = false,
+    inventory_loading = false
+  }
+  loaded = false
+  first_load_done = false
+
+  skillchains:destroy()
+  ui:destroy()
+end)
+
+windower.register_event('unload', function()
+  settings = nil
+  theme = nil
+  theme_options = nil
+  state = {
+    ready = false,
+    demo = false,
+    inventory_ready = false,
+    inventory_loading = false
+  }
+  loaded = false
+  first_load_done = false
+
+  skillchains:destroy()
+  ui:destroy()
 end)
 
 -- DARK ARTS / LIGHT ARTS / ADD:BLK / ADD:WHT  set "stance"


### PR DESCRIPTION
- Proper teardown of modules for character switching and addon reload, should reduce bugs with settings
- Changes many instances of st to t for ease of use
- Added more WS on BLM and BST example
- Tweaked BLM example
- Removed a lot of /rdm examples that had half-skill enfeebles
- Added WS template by skillchain property